### PR TITLE
brew by product name + recipe overrides; button platform per product

### DIFF
--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -22,7 +22,13 @@ except ImportError:
 
 
 if _HAS_HOMEASSISTANT:
-    PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER]
+    PLATFORMS = [
+        Platform.SENSOR,
+        Platform.BINARY_SENSOR,
+        Platform.SELECT,
+        Platform.NUMBER,
+        Platform.BUTTON,
+    ]
 
     SERVICE_FORCE_UPDATE = "force_update"
     SERVICE_LOCK_SCREEN = "lock_screen"
@@ -145,9 +151,7 @@ def _register_services(hass: HomeAssistant) -> None:
         coordinator = _get_coordinator(hass, config_entry_id)
         args = [call.data["recipe"]]
         args += [
-            f"{cli_key}={call.data[field]}"
-            for field, cli_key in _BREW_OVERRIDE_KEYS.items()
-            if field in call.data
+            f"{cli_key}={call.data[field]}" for field, cli_key in _BREW_OVERRIDE_KEYS.items() if field in call.data
         ]
         return await coordinator.run_command("brew", args, allow_destructive=True)
 

--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -58,7 +58,30 @@ if _HAS_HOMEASSISTANT:
         }
     )
 
-    BREW_SCHEMA = _BASE_TARGET_SCHEMA.extend({vol.Required("recipe"): str})
+    # Optional recipe overrides, passed to jura_connect's brew command as
+    # ``param=value`` args (the lib validates them against the machine XML
+    # and builds the @TP recipe blob). Keys here -> lib CLI keys below.
+    BREW_SCHEMA = _BASE_TARGET_SCHEMA.extend(
+        {
+            vol.Required("recipe"): str,
+            vol.Optional("water"): vol.Coerce(int),
+            vol.Optional("strength"): vol.Coerce(int),
+            vol.Optional("temperature"): vol.In(["low", "normal", "high"]),
+            vol.Optional("milk_foam"): vol.Coerce(int),
+            vol.Optional("milk_break"): vol.Coerce(int),
+            vol.Optional("bypass"): vol.Coerce(int),
+        }
+    )
+
+    # HA service field -> jura_connect brew CLI key.
+    _BREW_OVERRIDE_KEYS: dict[str, str] = {
+        "water": "water",
+        "strength": "strength",
+        "temperature": "temp",
+        "milk_foam": "milk",
+        "milk_break": "milk_break",
+        "bypass": "bypass",
+    }
 
 
 def _resolve_config_entry_id(hass: HomeAssistant, call_data: dict) -> str:
@@ -120,8 +143,13 @@ def _register_services(hass: HomeAssistant) -> None:
     async def handle_brew(call: ServiceCall) -> ServiceResponse:
         config_entry_id = _resolve_config_entry_id(hass, call.data)
         coordinator = _get_coordinator(hass, config_entry_id)
-        recipe = call.data["recipe"]
-        return await coordinator.run_command("brew", [recipe], allow_destructive=True)
+        args = [call.data["recipe"]]
+        args += [
+            f"{cli_key}={call.data[field]}"
+            for field, cli_key in _BREW_OVERRIDE_KEYS.items()
+            if field in call.data
+        ]
+        return await coordinator.run_command("brew", args, allow_destructive=True)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/jura/button.py
+++ b/custom_components/jura/button.py
@@ -1,0 +1,101 @@
+"""Button platform: one brew button per product from the machine profile.
+
+Pressing a button starts the product with the machine XML's default
+recipe (the same defaults the front panel uses). Parameterised brews —
+custom water amount, strength, temperature — go through the
+``jura.brew`` service instead; a stateless button can't carry fields.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_MACHINE_TYPE, DOMAIN
+from .coordinator import JuraCoordinator
+from .entity import JuraEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Icon per rough product family; default falls back to the coffee cup.
+_PRODUCT_ICONS = {
+    "hotwater": "mdi:kettle-steam",
+    "milk_foam": "mdi:beer-outline",
+    "cappuccino": "mdi:coffee",
+    "latte": "mdi:glass-mug-variant",
+    "macchiato": "mdi:glass-mug-variant",
+}
+_DEFAULT_ICON = "mdi:coffee"
+
+
+def _brewable_products(profile):
+    """Every product the profile exposes, in catalogue order.
+
+    The machine XML's PRODUCTS section is exactly the set the front
+    panel offers, so there is nothing to filter — powder products and
+    milk-only programs included.
+    """
+    return tuple(profile.products)
+
+
+def _icon_for(product_name: str) -> str:
+    for fragment, icon in _PRODUCT_ICONS.items():
+        if fragment in product_name:
+            return icon
+    return _DEFAULT_ICON
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: JuraCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    machine_type = config_entry.data.get(CONF_MACHINE_TYPE)
+    if not machine_type:
+        # Without a profile there is no product catalogue to enumerate;
+        # the jura.brew service (raw blob / code form) still works.
+        return
+
+    try:
+        from jura_connect import load_profile
+    except ImportError:  # pragma: no cover
+        return
+    try:
+        profile = load_profile(machine_type)
+    except KeyError:
+        _LOGGER.warning("no profile for machine_type %s; skipping brew buttons", machine_type)
+        return
+
+    async_add_entities(
+        ProductButtonEntity(coordinator, config_entry, product) for product in _brewable_products(profile)
+    )
+
+
+class ProductButtonEntity(JuraEntity, ButtonEntity):
+    """Starts one product with its XML-default recipe when pressed.
+
+    The press dispatches the lib's named ``brew`` command with just the
+    product name — jura_connect 0.10+ builds and validates the 16-byte
+    ``@TP:`` recipe blob from the machine profile's defaults.
+    """
+
+    def __init__(
+        self,
+        coordinator: JuraCoordinator,
+        config_entry: ConfigEntry,
+        product,
+    ) -> None:
+        super().__init__(coordinator, config_entry)
+        self._product = product
+        pretty = product.name.replace("_", " ")
+        self._attr_name = f"Brew {pretty}"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.name}"
+        self._attr_icon = _icon_for(product.name)
+
+    async def async_press(self) -> None:
+        await self.coordinator.run_command("brew", [self._product.name], allow_destructive=True)

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -1,13 +1,17 @@
 {
     "domain": "jura",
     "name": "Jura Connect",
-    "codeowners": ["@makefu"],
+    "codeowners": [
+        "@makefu"
+    ],
     "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/makefu/jura-connect-hass",
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
-    "requirements": ["jura_connect>=0.9.4"],
+    "requirements": [
+        "jura_connect>=0.10.0"
+    ],
     "version": "0.7.4"
 }

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -1,17 +1,13 @@
 {
     "domain": "jura",
     "name": "Jura Connect",
-    "codeowners": [
-        "@makefu"
-    ],
+    "codeowners": ["@makefu"],
     "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/makefu/jura-connect-hass",
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
-    "requirements": [
-        "jura_connect>=0.10.0"
-    ],
+    "requirements": ["jura_connect>=0.10.0"],
     "version": "0.7.4"
 }

--- a/custom_components/jura/services.yaml
+++ b/custom_components/jura/services.yaml
@@ -44,7 +44,11 @@ unlock_screen:
 
 brew:
   name: Brew
-  description: Start brewing a product. Recipe codes are firmware-specific (e.g. 01 = espresso on many models).
+  description: >-
+    Start brewing a product. Pass the product name from the machine profile
+    ("espresso", "cappuccino", "hotwater"…) or a 2-hex product code; optional
+    fields override the machine's defaults and are validated against the
+    machine XML before anything is sent.
   fields:
     config_entry_id:
       name: Config Entry ID
@@ -56,11 +60,68 @@ brew:
         entity:
           integration: jura
     recipe:
-      name: Recipe
-      description: Product code, e.g. "01" for espresso. Consult your machine's documentation.
+      name: Product
+      description: >-
+        Product name from the machine profile (e.g. "espresso", "hotwater";
+        unambiguous substrings work) or a 2-hex product code. A full 16-byte
+        recipe blob is accepted verbatim as an escape hatch.
       required: true
       selector:
         text:
+    water:
+      name: Water (ml)
+      description: Water amount in millilitres (validated per product, steps of 5).
+      selector:
+        number:
+          min: 15
+          max: 450
+          step: 5
+          unit_of_measurement: ml
+          mode: box
+    strength:
+      name: Coffee strength
+      description: Brew strength level (coffee products only).
+      selector:
+        number:
+          min: 1
+          max: 10
+          mode: box
+    temperature:
+      name: Temperature
+      selector:
+        select:
+          options:
+            - low
+            - normal
+            - high
+    milk_foam:
+      name: Milk foam (seconds)
+      description: Milk-foam dispensing time (milk products only).
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: s
+          mode: box
+    milk_break:
+      name: Milk break (seconds)
+      description: Pause between milk and coffee phases (latte macchiato etc.).
+      selector:
+        number:
+          min: 0
+          max: 60
+          unit_of_measurement: s
+          mode: box
+    bypass:
+      name: Bypass water (ml)
+      description: Extra hot water through the bypass (Café Barista etc.).
+      selector:
+        number:
+          min: 0
+          max: 240
+          step: 5
+          unit_of_measurement: ml
+          mode: box
 
 clean:
   name: Start Cleaning Cycle

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ class Platform:
     BINARY_SENSOR = "binary_sensor"
     SELECT = "select"
     NUMBER = "number"
+    BUTTON = "button"
 
 
 class EntityCategory(str, Enum):
@@ -334,6 +335,31 @@ class SelectEntity:
 
 
 _make_module("homeassistant.components.select", SelectEntity=SelectEntity)
+
+
+# --- homeassistant.components.button ---
+class ButtonEntity:
+    @property
+    def unique_id(self):
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def name(self):
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def icon(self):
+        return getattr(self, "_attr_icon", None)
+
+    @property
+    def entity_category(self):
+        return getattr(self, "_attr_entity_category", None)
+
+    async def async_press(self) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+_make_module("homeassistant.components.button", ButtonEntity=ButtonEntity)
 
 
 # --- homeassistant.components.number ---

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,56 @@
+"""Tests for the button platform: one brew button per profile product."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+jura_connect = pytest.importorskip("jura_connect")
+from jura_connect import load_profile  # noqa: E402
+
+from custom_components.jura.button import ProductButtonEntity, _brewable_products  # noqa: E402
+
+
+@pytest.fixture
+def ef538():
+    """The E8 (EB) profile — 15 products, including hot water."""
+    return load_profile("EF538")
+
+
+def _coordinator(run_command=None):
+    c = MagicMock()
+    c.data = MagicMock()
+    c.last_update_success = True
+    c.run_command = run_command or AsyncMock(return_value={"name": "brew", "value": "@tp"})
+    return c
+
+
+def test_brewable_products_covers_the_profile(ef538):
+    names = {p.name for p in _brewable_products(ef538)}
+    assert "espresso" in names
+    assert "hotwater_portion_normal" in names
+    assert "cappuccino" in names
+    # The full EF538 catalogue is exposed — nothing silently dropped.
+    assert len(names) == len(ef538.products)
+
+
+def test_button_entity_naming_and_unique_id(ef538, fake_config_entry):
+    espresso = ef538.product_by_code[0x02]
+    entity = ProductButtonEntity(_coordinator(), fake_config_entry, espresso)
+    assert entity.name == "Brew espresso"
+    assert entity.unique_id.endswith("brew_espresso")
+
+
+async def test_button_press_runs_brew_with_product_name(ef538, fake_config_entry):
+    hot_water = ef538.product_by_code[0x0D]
+    run = AsyncMock(return_value={"name": "brew", "value": "@tp"})
+    entity = ProductButtonEntity(_coordinator(run_command=run), fake_config_entry, hot_water)
+    await entity.async_press()
+    run.assert_awaited_once_with("brew", ["hotwater_portion_normal"], allow_destructive=True)
+
+
+def test_buttons_have_distinct_unique_ids(ef538, fake_config_entry):
+    coordinator = _coordinator()
+    ids = [ProductButtonEntity(coordinator, fake_config_entry, p).unique_id for p in _brewable_products(ef538)]
+    assert len(ids) == len(set(ids))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -127,6 +127,69 @@ async def test_brew_handler_passes_recipe_and_allow_destructive():
     assert result == {"name": "test", "value": "ok"}
 
 
+async def test_brew_handler_passes_recipe_overrides_in_cli_form():
+    """Optional recipe parameters become param=value args for the lib's
+    brew command (jura_connect >= 0.10 builds the @TP recipe blob)."""
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+
+    handler = hass.services._registered[(DOMAIN, "brew")]["handler"]
+    call = MagicMock()
+    call.data = {
+        "config_entry_id": "test_entry_id",
+        "recipe": "espresso",
+        "water": 35,
+        "strength": 7,
+        "temperature": "high",
+    }
+    await handler(call)
+
+    coordinator.run_command.assert_awaited_once_with(
+        "brew",
+        ["espresso", "water=35", "strength=7", "temp=high"],
+        allow_destructive=True,
+    )
+
+
+async def test_brew_handler_passes_milk_and_bypass_overrides():
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+
+    handler = hass.services._registered[(DOMAIN, "brew")]["handler"]
+    call = MagicMock()
+    call.data = {
+        "config_entry_id": "test_entry_id",
+        "recipe": "cappuccino",
+        "milk_foam": 20,
+        "milk_break": 5,
+        "bypass": 45,
+    }
+    await handler(call)
+
+    coordinator.run_command.assert_awaited_once_with(
+        "brew",
+        ["cappuccino", "milk=20", "milk_break=5", "bypass=45"],
+        allow_destructive=True,
+    )
+
+
+def test_brew_schema_validates_temperature_values():
+    from custom_components.jura import BREW_SCHEMA
+
+    ok = BREW_SCHEMA(
+        {"config_entry_id": "x", "recipe": "hotwater", "temperature": "high"}
+    )
+    assert ok["temperature"] == "high"
+    with pytest.raises(vol.Invalid):
+        BREW_SCHEMA(
+            {"config_entry_id": "x", "recipe": "hotwater", "temperature": "boiling"}
+        )
+    with pytest.raises(vol.Invalid):
+        BREW_SCHEMA({"config_entry_id": "x", "recipe": "hotwater", "water": "veel"})
+
+
 async def test_command_services_dispatch_with_destructive_allowed():
     coordinator = _mock_coordinator()
     hass = _hass_with_coordinator(coordinator)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -178,14 +178,10 @@ async def test_brew_handler_passes_milk_and_bypass_overrides():
 def test_brew_schema_validates_temperature_values():
     from custom_components.jura import BREW_SCHEMA
 
-    ok = BREW_SCHEMA(
-        {"config_entry_id": "x", "recipe": "hotwater", "temperature": "high"}
-    )
+    ok = BREW_SCHEMA({"config_entry_id": "x", "recipe": "hotwater", "temperature": "high"})
     assert ok["temperature"] == "high"
     with pytest.raises(vol.Invalid):
-        BREW_SCHEMA(
-            {"config_entry_id": "x", "recipe": "hotwater", "temperature": "boiling"}
-        )
+        BREW_SCHEMA({"config_entry_id": "x", "recipe": "hotwater", "temperature": "boiling"})
     with pytest.raises(vol.Invalid):
         BREW_SCHEMA({"config_entry_id": "x", "recipe": "hotwater", "water": "veel"})
 


### PR DESCRIPTION
## What

  Builds on makefu/jura-connect#2 (needs a jura_connect release
  with `JuraClient.brew` / the named-brew CLI — manifest bumped to `>=0.10.0`).

  1. **`jura.brew` service**: `recipe` now takes a product name from the
     machine profile (`espresso`, `hotwater`, …); new optional fields `water`,
     `strength`, `temperature`, `milk_foam`, `milk_break`, `bypass` are passed
     to the lib as `param=value` args and validated against the machine XML
     before anything is sent.
  2. **Button platform**: one `button.jura_<host>_brew_<product>` per product
     from the machine profile — press = brew with the XML-default recipe, same
     as the machine's own front panel. Parameterised brews stay on the service.

  ## Testing

  - 126 tests pass (7 new), ruff clean, TDD per AGENTS.md.
  - Live-verified on an E8 (EB) / EF538 behind a WiFi Connect dongle: service
    call with `recipe: hotwater, water: 50` and the brew buttons both dispense.
    call with `recipe: hotwater, water: 50` and the brew buttons both dispense.