### PR TITLE
feat: brew products from the UI (control panel + product-aware @TP: service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ declaration; Nix users get it pinned via the flake input.
   hardness on EF1091) with the min/max/step pulled from the profile XML.
 - **Brew control panel** — a compact, machine-wide set of controls for the
   next brew: a **Brew Product** select, plus **Brew Strength**, **Brew Water**
-  and **Brew Temperature** selects (each offering "Machine Default" alongside
-  the product's own options/range), and a single **Brew** button. Picking a
-  product re-scopes the parameter selects to that drink and resets them to the
-  machine default; parameters a product doesn't support (e.g. strength for hot
-  water) go unavailable. Pressing **Brew** physically brews the staged drink.
+  and **Brew Temperature** selects (each offering "Factory Default" alongside
+  the product's own options/range), and a single **Brew** button. "Factory
+  Default" sends that product's built-in (XML) default value — JURA's WiFi
+  protocol has no way to reuse the machine's own configured value, so every
+  brew sends explicit, range-clamped values. Picking a product re-scopes the
+  parameter selects to that drink and loads your saved choices for it (these
+  persist across restarts, per product); parameters a product doesn't support
+  (e.g. strength for hot water) go unavailable. Pressing **Brew** physically
+  brews the staged drink.
 
 ### Diagnostics (collapsed by default)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ declaration; Nix users get it pinned via the flake input.
   (espresso, coffee, cappuccino, macchiato, americano, …). Set is
   discovered from the machine; names from the profile when configured.
 - **Brew total** — lifetime brews across all recipes.
-- **Service `<kind>` level** — `cleaning`, `decalc`, `filter change` —
+- **Service `<kind>` level** — `cleaning`, `descale`, `filter change` —
   the percent-to-next-service indicators (0–100 %).
 - **Setting `<name>`** — current value of each machine setting (language,
   hardness, auto-off, units, …); item-driven settings surface as the
@@ -75,7 +75,7 @@ declaration; Nix users get it pinned via the flake input.
 - **Connectivity** — the canonical "is the machine reachable right now"
   signal (`binary_sensor` with `device_class=connectivity`). Wire
   automations against this rather than the per-entity `available` flag.
-- **Cycles `<kind>`** — the six maintenance counters (cleaning, decalc,
+- **Cycles `<kind>`** — the six maintenance counters (cleaning, descale,
   filter change, cappu rinse, coffee rinse, cappu clean).
 - Running / informational binary sensors (heating up, coffee ready,
   welcome, please wait, …).
@@ -94,9 +94,9 @@ for reachability.
 | `jura.force_update`    | Poll the machine immediately                          |
 | `jura.lock_screen`     | Lock the front-panel display                          |
 | `jura.unlock_screen`   | Unlock the front-panel display                        |
-| `jura.brew`            | Start brewing a recipe (`recipe: "01"` = espresso)    |
+| `jura.brew`            | Brew by `product` name (+ optional strength/water/temp) |
 | `jura.clean`           | Start coffee-system cleaning cycle (~5 min)           |
-| `jura.decalc`          | Start descaling cycle (30+ min, requires descaler)    |
+| `jura.descale`         | Start descaling cycle (30+ min, requires descaler)    |
 | `jura.filter_change`   | Run water-filter change procedure                     |
 | `jura.cappu_rinse`     | Rinse the milk system                                 |
 | `jura.cappu_clean`     | Clean the milk system (requires cleaning tablet)      |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ declaration; Nix users get it pinned via the flake input.
   Allowed: german=01, english=02, …" message rather than a backend error.
 - **`number.*`** entities for step-slider settings (currently water
   hardness on EF1091) with the min/max/step pulled from the profile XML.
+- **Brew control panel** — a compact, machine-wide set of controls for the
+  next brew: a **Brew Product** select, plus **Brew Strength**, **Brew Water**
+  and **Brew Temperature** selects (each offering "Machine Default" alongside
+  the product's own options/range), and a single **Brew** button. Picking a
+  product re-scopes the parameter selects to that drink and resets them to the
+  machine default; parameters a product doesn't support (e.g. strength for hot
+  water) go unavailable. Pressing **Brew** physically brews the staged drink.
 
 ### Diagnostics (collapsed by default)
 

--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from .brew import build_start_command, jura_connect_xml_dir, load_definition
+
 _LOGGER = logging.getLogger(__name__)
 
 try:
@@ -13,7 +15,7 @@ try:
     from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
     from homeassistant.helpers import entity_registry as er
 
-    from .const import DOMAIN
+    from .const import CONF_MACHINE_TYPE, DOMAIN
     from .coordinator import JuraCoordinator
 
     _HAS_HOMEASSISTANT = True
@@ -22,14 +24,21 @@ except ImportError:
 
 
 if _HAS_HOMEASSISTANT:
-    PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER]
+    PLATFORMS = [
+        Platform.SENSOR,
+        Platform.BINARY_SENSOR,
+        Platform.SELECT,
+        Platform.NUMBER,
+        Platform.BUTTON,
+    ]
 
     SERVICE_FORCE_UPDATE = "force_update"
     SERVICE_LOCK_SCREEN = "lock_screen"
     SERVICE_UNLOCK_SCREEN = "unlock_screen"
     SERVICE_BREW = "brew"
     SERVICE_CLEAN = "clean"
-    SERVICE_DECALC = "decalc"
+    SERVICE_DESCALE = "descale"
+    SERVICE_DECALC = "decalc"  # legacy alias of descale (back-compat)
     SERVICE_FILTER_CHANGE = "filter_change"
     SERVICE_CAPPU_RINSE = "cappu_rinse"
     SERVICE_CAPPU_CLEAN = "cappu_clean"
@@ -38,11 +47,15 @@ if _HAS_HOMEASSISTANT:
 
     # Map HA service name -> jura_connect command name. Every entry runs with
     # ``allow_destructive=True`` because the user invoked the dedicated service
-    # explicitly; the named service *is* the opt-in.
+    # explicitly; the named service *is* the opt-in. ``descale`` is the
+    # user-facing name for the library's ``decalc`` command; ``decalc`` is
+    # kept as a backwards-compatible alias so existing automations keep
+    # working.
     _COMMAND_SERVICES: dict[str, str] = {
         SERVICE_LOCK_SCREEN: "lock",
         SERVICE_UNLOCK_SCREEN: "unlock",
         SERVICE_CLEAN: "clean",
+        SERVICE_DESCALE: "decalc",
         SERVICE_DECALC: "decalc",
         SERVICE_FILTER_CHANGE: "filter-change",
         SERVICE_CAPPU_RINSE: "cappu-rinse",
@@ -58,7 +71,19 @@ if _HAS_HOMEASSISTANT:
         }
     )
 
-    BREW_SCHEMA = _BASE_TARGET_SCHEMA.extend({vol.Required("recipe"): str})
+    # ``brew`` accepts either a friendly ``product`` (name from the machine's
+    # product table; strength/water_ml/temperature override the XML defaults)
+    # or a raw ``recipe`` (the 16-byte hex payload, legacy path). Exactly one
+    # of ``product`` / ``recipe`` is required — enforced in the handler.
+    BREW_SCHEMA = _BASE_TARGET_SCHEMA.extend(
+        {
+            vol.Optional("recipe"): str,
+            vol.Optional("product"): str,
+            vol.Optional("strength"): vol.Coerce(int),
+            vol.Optional("water_ml"): vol.Coerce(int),
+            vol.Optional("temperature"): vol.Coerce(int),
+        }
+    )
 
 
 def _resolve_config_entry_id(hass: HomeAssistant, call_data: dict) -> str:
@@ -83,6 +108,24 @@ def _get_coordinator(hass: HomeAssistant, config_entry_id: str) -> JuraCoordinat
     if config_entry_id not in hass.data.get(DOMAIN, {}):
         raise ValueError(f"Config entry {config_entry_id} not found")
     return hass.data[DOMAIN][config_entry_id]
+
+
+def _find_product(machine_type: str | None, name: str):
+    """Resolve a product *name* to its definition for ``machine_type``.
+
+    Products come from jura_connect's bundled XMLs (matched case-insensitively
+    by name). Returns ``None`` when the data, definition or product is missing.
+    """
+    base_dir = jura_connect_xml_dir()
+    if base_dir is None:
+        return None
+    definition = load_definition(machine_type, base_dir=base_dir)
+    if definition is None:
+        return None
+    for product in definition.products:
+        if product.name.casefold() == name.casefold():
+            return product
+    return None
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -120,7 +163,24 @@ def _register_services(hass: HomeAssistant) -> None:
     async def handle_brew(call: ServiceCall) -> ServiceResponse:
         config_entry_id = _resolve_config_entry_id(hass, call.data)
         coordinator = _get_coordinator(hass, config_entry_id)
-        recipe = call.data["recipe"]
+        product_name = call.data.get("product")
+        recipe = call.data.get("recipe")
+        if product_name and recipe:
+            raise vol.Invalid("Provide either product or recipe, not both")
+        if product_name:
+            machine_type = coordinator.config_entry.data.get(CONF_MACHINE_TYPE)
+            product = _find_product(machine_type, product_name)
+            if product is None:
+                raise ValueError(f"Unknown product {product_name!r} for machine {machine_type!r}")
+            payload = build_start_command(
+                product,
+                strength=call.data.get("strength"),
+                water_ml=call.data.get("water_ml"),
+                temp=call.data.get("temperature"),
+            )
+            recipe = payload.removeprefix("@TP:")
+        elif not recipe:
+            raise vol.Invalid("Provide either product or recipe")
         return await coordinator.run_command("brew", [recipe], allow_destructive=True)
 
     hass.services.async_register(

--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -128,6 +128,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Jura from a config entry."""
     coordinator = JuraCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
+    # Restore persisted per-product brew preferences (strength/water/temp),
+    # keyed by product Code, so the brew panel remembers them across restarts.
+    await coordinator.async_load_brew_prefs()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -38,7 +38,6 @@ if _HAS_HOMEASSISTANT:
     SERVICE_BREW = "brew"
     SERVICE_CLEAN = "clean"
     SERVICE_DESCALE = "descale"
-    SERVICE_DECALC = "decalc"  # legacy alias of descale (back-compat)
     SERVICE_FILTER_CHANGE = "filter_change"
     SERVICE_CAPPU_RINSE = "cappu_rinse"
     SERVICE_CAPPU_CLEAN = "cappu_clean"
@@ -48,15 +47,12 @@ if _HAS_HOMEASSISTANT:
     # Map HA service name -> jura_connect command name. Every entry runs with
     # ``allow_destructive=True`` because the user invoked the dedicated service
     # explicitly; the named service *is* the opt-in. ``descale`` is the
-    # user-facing name for the library's ``decalc`` command; ``decalc`` is
-    # kept as a backwards-compatible alias so existing automations keep
-    # working.
+    # user-facing name for the library's ``decalc`` command.
     _COMMAND_SERVICES: dict[str, str] = {
         SERVICE_LOCK_SCREEN: "lock",
         SERVICE_UNLOCK_SCREEN: "unlock",
         SERVICE_CLEAN: "clean",
         SERVICE_DESCALE: "decalc",
-        SERVICE_DECALC: "decalc",
         SERVICE_FILTER_CHANGE: "filter-change",
         SERVICE_CAPPU_RINSE: "cappu-rinse",
         SERVICE_CAPPU_CLEAN: "cappu-clean",

--- a/custom_components/jura/binary_sensor.py
+++ b/custom_components/jura/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import ALERT_BINARY_SENSORS, DIAGNOSTIC_ALERT_DEVICE_CLASSES, DOMAIN
+from .const import ALERT_BINARY_SENSORS, DIAGNOSTIC_ALERT_DEVICE_CLASSES, DOMAIN, FRIENDLY_LABELS
 from .coordinator import JuraCoordinator
 from .entity import JuraEntity
 
@@ -42,7 +42,7 @@ class AlertBinarySensor(JuraEntity, BinarySensorEntity):
         # "Alert" prefix groups every alert binary_sensor together on the
         # device card. Sort order within the group is then alphabetical
         # by alert name.
-        self._attr_name = f"Alert {alert.replace('_', ' ')}"
+        self._attr_name = f"Alert {FRIENDLY_LABELS.get(alert, alert).replace('_', ' ')}"
         self._attr_unique_id = f"{DOMAIN}_{self._slug}_alert_{alert}"
         if device_class is not None:
             try:

--- a/custom_components/jura/brew/__init__.py
+++ b/custom_components/jura/brew/__init__.py
@@ -25,9 +25,11 @@ from .definitions import (
     load_definition,
     parse_definition_xml,
 )
+from .prefs import BREW_PARAMS, product_prefs, remember_param, selection_for_product
 from .products import build_start_command
 
 __all__ = [
+    "BREW_PARAMS",
     "AlertDef",
     "MachineDefinition",
     "ProductArg",
@@ -37,6 +39,9 @@ __all__ = [
     "jura_connect_xml_dir",
     "load_definition",
     "parse_definition_xml",
+    "product_prefs",
+    "remember_param",
+    "selection_for_product",
 ]
 
 

--- a/custom_components/jura/brew/__init__.py
+++ b/custom_components/jura/brew/__init__.py
@@ -1,0 +1,58 @@
+"""Framework-free brew payload + machine-definition helpers.
+
+Ported verbatim from the ha-jura-wifi project (pure stdlib, no Home
+Assistant imports) so the ``@TP:`` start-command encoding can be unit
+tested without HA and reused by the button / select / number platforms
+and the ``jura.brew`` service.
+
+The machine-definition XMLs are NOT re-bundled here. makefu's
+``jura_connect`` package already vendors them as package data under
+``jura_connect/data/xml/<EF>/<ver>.xml``; :func:`jura_connect_xml_dir`
+resolves that directory with :mod:`importlib.resources` and the parser
+in :mod:`.definitions` reads from it.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .definitions import (
+    AlertDef,
+    MachineDefinition,
+    ProductArg,
+    ProductDef,
+    definition_dir_for_type,
+    load_definition,
+    parse_definition_xml,
+)
+from .products import build_start_command
+
+__all__ = [
+    "AlertDef",
+    "MachineDefinition",
+    "ProductArg",
+    "ProductDef",
+    "build_start_command",
+    "definition_dir_for_type",
+    "jura_connect_xml_dir",
+    "load_definition",
+    "parse_definition_xml",
+]
+
+
+def jura_connect_xml_dir() -> str | None:
+    """Return the path to jura_connect's bundled machine-definition XMLs.
+
+    Returns the filesystem path of ``jura_connect/data/xml`` (suitable as
+    ``base_dir`` for :func:`load_definition` / :func:`definition_dir_for_type`),
+    or ``None`` when the ``jura_connect`` package — or its data dir — is
+    unavailable.
+    """
+    from importlib.resources import files
+
+    try:
+        base = files("jura_connect") / "data" / "xml"
+    except ModuleNotFoundError:
+        return None
+    path = str(base)
+    return path if os.path.isdir(path) else None

--- a/custom_components/jura/brew/definitions.py
+++ b/custom_components/jura/brew/definitions.py
@@ -173,9 +173,11 @@ def _parse_product(element: ET.Element) -> ProductDef:
 def parse_definition_xml(path: str) -> MachineDefinition:
     """Parse a machine-definition XML into a :class:`MachineDefinition`.
 
-    Only ``Active="true"`` products are included. Counter names are collected
-    from the ``TOTALCOUNTER`` plus each active product's ``PosCSV``. Alerts map
-    each ``<ALERT Bit Name>`` to its human-readable name.
+    Products are active unless their ``Active`` attribute is explicitly non-
+    ``"true"`` (matching the J.O.E. app, which seeds the flag to true and only
+    overrides it when the attribute is present). Counter names are collected from
+    the ``TOTALCOUNTER`` plus each ``Active="true"`` product's ``PosCSV``. Alerts
+    map each ``<ALERT Bit Name>`` to its human-readable name.
     """
     root = ET.parse(path).getroot()
 
@@ -190,11 +192,20 @@ def parse_definition_xml(path: str) -> MachineDefinition:
             if pos is not None and pos.isdigit():
                 counters[int(pos)] = element.get("Name") or "Total Products"
         elif tag == "PRODUCT":
-            if (element.get("Active") or "").lower() != "true":
+            # The J.O.E. app treats a product as active unless its Active flag is
+            # explicitly non-"true": it seeds the flag to true and only overrides
+            # it when the attribute is present (XMLParser.java `boolean z7 = true`).
+            # A missing Active attribute therefore means the drink is brewable.
+            active = element.get("Active")
+            if active is not None and active.strip().lower() != "true":
                 continue
             product = _parse_product(element)
             products.append(product)
-            if product.pos_csv is not None:
+            # Counter labels stay tied to the strict Active="true" set: that
+            # mapping is validated against live @TR:32 captures and PosCSV is not
+            # unique across products (Coffee, Cafe Barista and Barista Lungo all
+            # use PosCSV 4), so only an explicitly-active product owns the label.
+            if product.pos_csv is not None and (active or "").strip().lower() == "true":
                 counters[product.pos_csv] = product.name
         elif tag == "ALERT":
             bit = element.get("Bit")

--- a/custom_components/jura/brew/definitions.py
+++ b/custom_components/jura/brew/definitions.py
@@ -1,0 +1,276 @@
+"""Parse JURA machine-definition XMLs (J.O.E. ``joe_control`` schema).
+
+Each machine ships a definition under ``<GROUP>/<version>.xml`` that
+describes its products (and how to encode a product-start command), its alert
+bit -> human-name map, and the product-counter slot names. This module turns one
+of those XMLs into plain dataclasses; it is framework-free (stdlib ``xml.etree``
+only) so the protocol logic can be used without Home Assistant installed.
+
+Ported verbatim from the ha-jura-wifi project. The XMLs themselves are NOT
+bundled with this integration; the caller supplies ``base_dir`` (see
+:func:`custom_components.jura.brew.jura_connect_xml_dir`, which points at the
+``jura_connect`` package's vendored data).
+
+Argument indices (used by :mod:`.products`): a product argument's ``Argument``
+attribute is ``F<n>`` and maps to byte index ``n - 1`` of the 16-byte start
+payload -- COFFEE_STRENGTH ``F3`` -> 2, WATER_AMOUNT ``F4`` -> 3, TEMPERATURE
+``F7`` -> 6. Counter slots map ``counter index = PosCSV - 1`` (validated against
+live ``@TR:32`` captures).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+
+# Fallback definition root (unused in this integration: the caller always
+# passes ``base_dir`` resolved from the jura_connect package data).
+DEFINITIONS_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "definitions"))
+
+# Product child tags we encode into the start command.
+ARG_KINDS = ("COFFEE_STRENGTH", "WATER_AMOUNT", "TEMPERATURE")
+
+_TYPE_RE = re.compile(r"(EF\d+\w*)")
+_BASE_RE = re.compile(r"(EF\d+)")
+
+
+@dataclass(frozen=True)
+class ProductArg:
+    """One adjustable product argument (strength / water / temperature).
+
+    ``index`` is the byte position in the 16-byte ``@TP:`` payload. ``default``
+    is the byte value for strength/temperature (parsed from the hex ``Default``)
+    or the default millilitres for water (parsed from decimal ``Value``); water
+    also carries ``min``/``max``/``step`` and is encoded as ``ml // step``.
+    """
+
+    kind: str
+    argument: str
+    index: int
+    default: int
+    min: int | None = None
+    max: int | None = None
+    step: int | None = None
+    items: tuple[tuple[str, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class ProductDef:
+    """A single brewable product and its adjustable arguments."""
+
+    code: str
+    name: str
+    picture: str | None
+    pos_csv: int | None
+    args: tuple[ProductArg, ...] = ()
+
+    def arg(self, kind: str) -> ProductArg | None:
+        """Return the argument of ``kind`` for this product, or ``None``."""
+        for candidate in self.args:
+            if candidate.kind == kind:
+                return candidate
+        return None
+
+
+@dataclass(frozen=True)
+class AlertDef:
+    """A status-bit alert: bit index -> human-readable name.
+
+    ``type`` mirrors the XML ``Type`` attribute (``"block"``, ``"info"``,
+    ``"ip"`` or ``None``) and lets the binary-sensor platform pick a sensible
+    device class without inventing a classification.
+    """
+
+    bit: int
+    name: str
+    type: str | None = None
+
+
+@dataclass
+class MachineDefinition:
+    """Everything we decode from one machine-definition XML."""
+
+    products: tuple[ProductDef, ...]
+    alerts: tuple[AlertDef, ...]
+    counters_by_poscsv: dict[int, str] = field(default_factory=dict)
+    machine_type: str | None = None
+
+
+def _local(tag: str) -> str:
+    """Strip an XML namespace, returning the bare local tag name."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _int(value: str | None) -> int | None:
+    """Parse a decimal integer attribute, tolerating absence/garbage."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _parse_arg(kind: str, element: ET.Element) -> ProductArg:
+    """Parse a COFFEE_STRENGTH / WATER_AMOUNT / TEMPERATURE element."""
+    argument = element.get("Argument") or ""
+    index = int(argument[1:]) - 1 if argument[1:].isdigit() else -1
+
+    items: list[tuple[str, int]] = []
+    for item in element:
+        if _local(item.tag) != "ITEM":
+            continue
+        raw = item.get("Value")
+        try:
+            value = int(raw, 16) if raw else 0
+        except ValueError:
+            value = 0
+        items.append((item.get("Name") or "", value))
+
+    if kind == "WATER_AMOUNT":
+        default = _int(element.get("Value")) or _int(element.get("Default")) or 0
+        return ProductArg(
+            kind=kind,
+            argument=argument,
+            index=index,
+            default=default,
+            min=_int(element.get("Min")),
+            max=_int(element.get("Max")),
+            step=_int(element.get("Step")),
+            items=tuple(items),
+        )
+
+    # strength / temperature: the Default attribute is a single hex byte.
+    try:
+        default = int(element.get("Default") or "00", 16)
+    except ValueError:
+        default = 0
+    return ProductArg(
+        kind=kind,
+        argument=argument,
+        index=index,
+        default=default,
+        items=tuple(items),
+    )
+
+
+def _parse_product(element: ET.Element) -> ProductDef:
+    """Parse one ``<PRODUCT>`` element and its encodable arguments."""
+    pos = element.get("PosCSV")
+    pos_csv = int(pos) if pos is not None and pos.isdigit() else None
+    args = [_parse_arg(_local(child.tag), child) for child in element if _local(child.tag) in ARG_KINDS]
+    return ProductDef(
+        code=element.get("Code") or "",
+        name=element.get("Name") or "",
+        picture=element.get("PictureIdle"),
+        pos_csv=pos_csv,
+        args=tuple(args),
+    )
+
+
+def parse_definition_xml(path: str) -> MachineDefinition:
+    """Parse a machine-definition XML into a :class:`MachineDefinition`.
+
+    Only ``Active="true"`` products are included. Counter names are collected
+    from the ``TOTALCOUNTER`` plus each active product's ``PosCSV``. Alerts map
+    each ``<ALERT Bit Name>`` to its human-readable name.
+    """
+    root = ET.parse(path).getroot()
+
+    products: list[ProductDef] = []
+    alerts: list[AlertDef] = []
+    counters: dict[int, str] = {}
+
+    for element in root.iter():
+        tag = _local(element.tag)
+        if tag == "TOTALCOUNTER":
+            pos = element.get("PosCSV")
+            if pos is not None and pos.isdigit():
+                counters[int(pos)] = element.get("Name") or "Total Products"
+        elif tag == "PRODUCT":
+            if (element.get("Active") or "").lower() != "true":
+                continue
+            product = _parse_product(element)
+            products.append(product)
+            if product.pos_csv is not None:
+                counters[product.pos_csv] = product.name
+        elif tag == "ALERT":
+            bit = element.get("Bit")
+            if bit is not None and bit.lstrip("-").isdigit():
+                alerts.append(
+                    AlertDef(
+                        bit=int(bit),
+                        name=element.get("Name") or "",
+                        type=element.get("Type"),
+                    )
+                )
+
+    return MachineDefinition(
+        products=tuple(products),
+        alerts=tuple(alerts),
+        counters_by_poscsv=counters,
+        machine_type=root.get("Group"),
+    )
+
+
+def definition_dir_for_type(machine_type: str | None, base_dir: str = DEFINITIONS_DIR) -> str | None:
+    """Resolve a reported machine type to a bundled definition directory name.
+
+    Takes the leading ``EF<digits><letters>`` token (e.g. ``"EF1030M"`` from
+    ``"EF1030M V01.06"``), tries it as an exact directory, then falls back to the
+    numeric base (``"EF1030"``). Returns the directory name that exists, else
+    ``None``.
+    """
+    if not machine_type:
+        return None
+    match = _TYPE_RE.match(machine_type.strip()) or _TYPE_RE.search(machine_type)
+    if not match:
+        return None
+    token = match.group(1)
+    if os.path.isdir(os.path.join(base_dir, token)):
+        return token
+    base = _BASE_RE.match(token)
+    if base:
+        base_name = base.group(1)
+        if base_name != token and os.path.isdir(os.path.join(base_dir, base_name)):
+            return base_name
+    return None
+
+
+def _version_key(stem: str) -> tuple[int, ...]:
+    """Sort key for a ``<major>.<minor>`` version filename stem."""
+    parts: list[int] = []
+    for piece in stem.split("."):
+        parts.append(int(piece) if piece.isdigit() else -1)
+    return tuple(parts) if parts else (-1,)
+
+
+def _highest_version_xml(dir_path: str) -> str | None:
+    """Return the path of the highest-version ``*.xml`` file in ``dir_path``."""
+    best: str | None = None
+    best_key: tuple[int, ...] | None = None
+    for fname in os.listdir(dir_path):
+        if not fname.lower().endswith(".xml"):
+            continue
+        key = _version_key(fname[:-4])
+        if best_key is None or key > best_key:
+            best_key = key
+            best = os.path.join(dir_path, fname)
+    return best
+
+
+def load_definition(machine_type: str | None, base_dir: str = DEFINITIONS_DIR) -> MachineDefinition | None:
+    """Resolve ``machine_type`` to its bundled definition and parse it.
+
+    Returns ``None`` when no directory matches the type or the directory holds no
+    XML file.
+    """
+    dir_name = definition_dir_for_type(machine_type, base_dir)
+    if dir_name is None:
+        return None
+    xml_path = _highest_version_xml(os.path.join(base_dir, dir_name))
+    if xml_path is None:
+        return None
+    return parse_definition_xml(xml_path)

--- a/custom_components/jura/brew/definitions.py
+++ b/custom_components/jura/brew/definitions.py
@@ -29,8 +29,11 @@ from dataclasses import dataclass, field
 # passes ``base_dir`` resolved from the jura_connect package data).
 DEFINITIONS_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "definitions"))
 
-# Product child tags we encode into the start command.
-ARG_KINDS = ("COFFEE_STRENGTH", "WATER_AMOUNT", "TEMPERATURE")
+# Product child tags we encode into the start command. MinMax args carry
+# Value/Min/Max/Step and encode as ``value // step`` (water, milk-foam amount,
+# bypass); strength/temperature instead pick a named ITEM byte.
+MINMAX_ARG_KINDS = ("WATER_AMOUNT", "MILK_FOAM_AMOUNT", "BYPASS")
+ARG_KINDS = ("COFFEE_STRENGTH", "TEMPERATURE", *MINMAX_ARG_KINDS)
 
 _TYPE_RE = re.compile(r"(EF\d+\w*)")
 _BASE_RE = re.compile(r"(EF\d+)")
@@ -129,7 +132,7 @@ def _parse_arg(kind: str, element: ET.Element) -> ProductArg:
             value = 0
         items.append((item.get("Name") or "", value))
 
-    if kind == "WATER_AMOUNT":
+    if kind in MINMAX_ARG_KINDS:
         default = _int(element.get("Value")) or _int(element.get("Default")) or 0
         return ProductArg(
             kind=kind,

--- a/custom_components/jura/brew/prefs.py
+++ b/custom_components/jura/brew/prefs.py
@@ -1,0 +1,56 @@
+"""Pure (framework-free) per-product brew-preference helpers.
+
+A *brew preference* is the remembered strength / water / temperature for a
+single product, keyed by the product's hex Code (e.g. ``"03"``). The on-disk /
+in-memory shape is::
+
+    brew_prefs: dict[str, dict] = {
+        "03": {"strength": 2, "water_ml": 130, "temp": None},
+        ...
+    }
+
+``None`` for any parameter means **Factory Default**: send that product's
+XML/factory default value (pass ``None`` to
+:func:`custom_components.jura.brew.build_start_command`). It does NOT mean "use
+whatever the machine currently has stored" — JURA WiFi exposes no such
+mechanism (truncated start payloads are rejected and per-byte sentinels are
+taken literally), so we always send an explicit, clamped value.
+
+These helpers only manipulate plain JSON-safe dicts so they can be unit-tested
+without Home Assistant or a Store, and reused by the coordinator (which adds
+the actual persistence + staged-selection wiring on top).
+"""
+
+from __future__ import annotations
+
+# The three adjustable recipe axes a preference can pin per product.
+BREW_PARAMS: tuple[str, ...] = ("strength", "water_ml", "temp")
+
+
+def product_prefs(brew_prefs: dict[str, dict], code: str) -> dict[str, int | None]:
+    """Return ``code``'s stored prefs, with every missing param as ``None``.
+
+    Both an absent product and an absent / explicitly-``None`` parameter map to
+    ``None`` (Factory Default), so callers get a uniform full dict.
+    """
+    stored = brew_prefs.get(code) or {}
+    return {param: stored.get(param) for param in BREW_PARAMS}
+
+
+def selection_for_product(brew_prefs: dict[str, dict], code: str) -> dict[str, int | str | None]:
+    """Build a ``brew_selection`` dict for ``code`` from its saved prefs.
+
+    The returned dict carries the product ``code`` plus each remembered
+    parameter (``None`` == Factory Default), ready to merge into the
+    coordinator's staged ``brew_selection``.
+    """
+    return {"product": code, **product_prefs(brew_prefs, code)}
+
+
+def remember_param(brew_prefs: dict[str, dict], code: str, param: str, value: int | None) -> None:
+    """Persist ``value`` for ``param`` of product ``code`` (mutates ``brew_prefs``).
+
+    ``value`` may be ``None`` to explicitly record Factory Default for that
+    parameter.
+    """
+    brew_prefs.setdefault(code, {})[param] = value

--- a/custom_components/jura/brew/products.py
+++ b/custom_components/jura/brew/products.py
@@ -26,6 +26,38 @@ from .definitions import ProductArg, ProductDef
 PREFIX = "@TP:"
 _PAYLOAD_BYTES = 16
 _FIXED_INDEX = 8  # byte 8 is always 0x01 in a start command.
+_MAX_BYTE = 0xFF
+
+
+def _clamp_to_items(value: int, items: tuple[tuple[str, int], ...]) -> int:
+    """Clamp ``value`` to the [min, max] span of an argument's ITEM byte values.
+
+    Used for strength / temperature, whose valid values are an explicit set of
+    named ITEMs. No-op when the argument carries no items.
+    """
+    if not items:
+        return value
+    values = [byte for _, byte in items]
+    return max(min(values), min(value, max(values)))
+
+
+def _encode_water(arg: ProductArg, water_ml: int | None) -> int:
+    """Resolve the water byte: ``ml // step``, with ml clamped to [min, max].
+
+    A ``None`` override means Factory Default -> the product's XML default ml,
+    which is authoritative and encoded as-is. An explicit override is clamped to
+    the product's [Min, Max] range first; JURA WiFi treats the water byte as a
+    literal ``byte * step`` ml, so an unclamped value would over/under-fill.
+    """
+    step = arg.step or 1
+    if water_ml is None:
+        return arg.default // step
+    ml = water_ml
+    if arg.min is not None:
+        ml = max(arg.min, ml)
+    if arg.max is not None:
+        ml = min(arg.max, ml)
+    return ml // step
 
 
 def _arg_value(
@@ -35,15 +67,23 @@ def _arg_value(
     water_ml: int | None,
     temp: int | None,
 ) -> int | None:
-    """Resolve one argument's byte value, honouring overrides then defaults."""
+    """Resolve one argument's byte value, honouring (clamped) overrides then defaults.
+
+    A ``None`` override == Factory Default: the product's XML/factory default
+    byte is emitted unchanged (it is authoritative and already valid). There is
+    deliberately no "use the machine's own stored setting" path — JURA WiFi has
+    no such mechanism, so explicit overrides are clamped into range instead.
+    """
     if arg.kind == "COFFEE_STRENGTH":
-        return strength if strength is not None else arg.default
+        if strength is None:
+            return arg.default
+        return _clamp_to_items(strength, arg.items)
     if arg.kind == "TEMPERATURE":
-        return temp if temp is not None else arg.default
+        if temp is None:
+            return arg.default
+        return _clamp_to_items(temp, arg.items)
     if arg.kind == "WATER_AMOUNT":
-        ml = water_ml if water_ml is not None else arg.default
-        step = arg.step or 1
-        return ml // step
+        return _encode_water(arg, water_ml)
     return None
 
 
@@ -56,8 +96,11 @@ def build_start_command(
 ) -> str:
     """Encode the ``@TP:`` start command for ``product``.
 
-    Unset keyword overrides fall back to each argument's definition default;
-    water is encoded as ``ml // step``. Returns ``"@TP:" + <32 uppercase hex>``.
+    Unset keyword overrides (``None``) fall back to each argument's XML/factory
+    default (Factory Default); explicit overrides are clamped to the argument's
+    valid range/ITEM set. Water is encoded as ``ml // step``. Every byte is
+    finally capped at ``0xFF`` so the payload can never overflow. Returns
+    ``"@TP:" + <32 uppercase hex>``.
     """
     payload = ["00"] * _PAYLOAD_BYTES
     payload[0] = f"{int(product.code, 16):02X}"
@@ -68,7 +111,7 @@ def build_start_command(
         value = _arg_value(arg, strength=strength, water_ml=water_ml, temp=temp)
         if value is None:
             continue
-        payload[arg.index] = f"{value & 0xFF:02X}"
+        payload[arg.index] = f"{max(0, min(value, _MAX_BYTE)):02X}"
 
     payload[_FIXED_INDEX] = "01"
     return PREFIX + "".join(payload).upper()

--- a/custom_components/jura/brew/products.py
+++ b/custom_components/jura/brew/products.py
@@ -1,0 +1,74 @@
+"""Build the ``@TP:`` product-start command for a JURA WiFi machine.
+
+The command is ``"@TP:"`` followed by a 16-byte hex payload (uppercase). The
+encoding was validated live on a JURA E6 (a real coffee brewed from it):
+
+    byte 0          product Code (e.g. 0x03 Coffee, 0x02 Espresso)
+    byte arg.index  each argument value, where index = Fnum - 1:
+                      COFFEE_STRENGTH F3 -> 2   value = chosen level byte
+                      WATER_AMOUNT    F4 -> 3   value = ml // step
+                      TEMPERATURE     F7 -> 6   value = chosen item byte
+    byte 8          0x01 (fixed)
+    byte 15         0x00 (grinder default)
+    all other bytes 0x00
+
+Validated vector: Coffee(0x03), strength 2, 130 ml, temp Normal(0x01) ->
+``@TP:0300021A000001000100000000000000`` (130 // 5 = 26 = 0x1A).
+
+This module never sends anything; it only encodes the string. The actual brew is
+triggered by an explicit Home Assistant button press / service call at runtime.
+"""
+
+from __future__ import annotations
+
+from .definitions import ProductArg, ProductDef
+
+PREFIX = "@TP:"
+_PAYLOAD_BYTES = 16
+_FIXED_INDEX = 8  # byte 8 is always 0x01 in a start command.
+
+
+def _arg_value(
+    arg: ProductArg,
+    *,
+    strength: int | None,
+    water_ml: int | None,
+    temp: int | None,
+) -> int | None:
+    """Resolve one argument's byte value, honouring overrides then defaults."""
+    if arg.kind == "COFFEE_STRENGTH":
+        return strength if strength is not None else arg.default
+    if arg.kind == "TEMPERATURE":
+        return temp if temp is not None else arg.default
+    if arg.kind == "WATER_AMOUNT":
+        ml = water_ml if water_ml is not None else arg.default
+        step = arg.step or 1
+        return ml // step
+    return None
+
+
+def build_start_command(
+    product: ProductDef,
+    *,
+    strength: int | None = None,
+    water_ml: int | None = None,
+    temp: int | None = None,
+) -> str:
+    """Encode the ``@TP:`` start command for ``product``.
+
+    Unset keyword overrides fall back to each argument's definition default;
+    water is encoded as ``ml // step``. Returns ``"@TP:" + <32 uppercase hex>``.
+    """
+    payload = ["00"] * _PAYLOAD_BYTES
+    payload[0] = f"{int(product.code, 16):02X}"
+
+    for arg in product.args:
+        if not 0 <= arg.index < _PAYLOAD_BYTES:
+            continue
+        value = _arg_value(arg, strength=strength, water_ml=water_ml, temp=temp)
+        if value is None:
+            continue
+        payload[arg.index] = f"{value & 0xFF:02X}"
+
+    payload[_FIXED_INDEX] = "01"
+    return PREFIX + "".join(payload).upper()

--- a/custom_components/jura/brew/products.py
+++ b/custom_components/jura/brew/products.py
@@ -8,6 +8,8 @@ encoding was validated live on a JURA E6 (a real coffee brewed from it):
                       COFFEE_STRENGTH F3 -> 2   value = chosen level byte
                       WATER_AMOUNT    F4 -> 3   value = ml // step
                       TEMPERATURE     F7 -> 6   value = chosen item byte
+                      MILK_FOAM_AMOUNT F6 -> 5  value = amount // step
+                      BYPASS          F10 -> 9  value = ml // step
     byte 8          0x01 (fixed)
     byte 15         0x00 (grinder default)
     all other bytes 0x00
@@ -21,7 +23,7 @@ triggered by an explicit Home Assistant button press / service call at runtime.
 
 from __future__ import annotations
 
-from .definitions import ProductArg, ProductDef
+from .definitions import MINMAX_ARG_KINDS, ProductArg, ProductDef
 
 PREFIX = "@TP:"
 _PAYLOAD_BYTES = 16
@@ -82,8 +84,12 @@ def _arg_value(
         if temp is None:
             return arg.default
         return _clamp_to_items(temp, arg.items)
-    if arg.kind == "WATER_AMOUNT":
-        return _encode_water(arg, water_ml)
+    if arg.kind in MINMAX_ARG_KINDS:
+        # All MinMax args encode as ``value // step`` (``_encode_water`` is the
+        # shared helper). Only water is user-overridable today; milk-foam amount
+        # (F6) and bypass (F10) brew at their default instead of staying 0x00.
+        override = water_ml if arg.kind == "WATER_AMOUNT" else None
+        return _encode_water(arg, override)
     return None
 
 

--- a/custom_components/jura/button.py
+++ b/custom_components/jura/button.py
@@ -1,12 +1,11 @@
-"""Button platform: one "Brew <product>" button per machine product.
+"""Button platform: a single "Brew" button driving the brew control panel.
 
-Pressing a button PHYSICALLY brews a drink on the machine. The button
-encodes the full 16-byte ``@TP:`` start command from the machine's
-product definition (sourced from the ``jura_connect`` package data) and
-the per-product parameters staged on the coordinator by the brew
-strength/water/temperature entities, then dispatches the library's
-``brew`` command (with ``allow_destructive=True`` — pressing the button
-is the explicit opt-in).
+Pressing the button PHYSICALLY brews a drink. It reads the machine-wide
+``coordinator.brew_selection`` (product + optional strength/water/temperature
+staged by the brew selects), encodes the 16-byte ``@TP:`` start command from
+the product's definition — a ``None`` parameter falls back to that product's
+XML default — and dispatches the library's ``brew`` command (with
+``allow_destructive=True``; pressing the button is the explicit opt-in).
 """
 
 from __future__ import annotations
@@ -18,8 +17,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .brew import ProductDef, build_start_command, jura_connect_xml_dir, load_definition
-from .const import CONF_MACHINE_TYPE, DOMAIN
+from .brew import build_start_command
+from .const import DOMAIN
 from .coordinator import JuraCoordinator
 from .entity import JuraEntity
 
@@ -32,49 +31,41 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: JuraCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    machine_type = config_entry.data.get(CONF_MACHINE_TYPE)
-    if not machine_type:
+    # No product table (missing jura_connect data / unknown machine type) ->
+    # nothing brewable, so no button. Mirrors the select/number platforms.
+    definition = coordinator.brew_definition
+    if definition is None or not definition.products:
         return
-
-    # Products come from jura_connect's bundled machine-definition XMLs.
-    # A missing package / profile is a configuration / version-skew issue —
-    # log and skip rather than crash the integration (mirrors select.py).
-    base_dir = jura_connect_xml_dir()
-    if base_dir is None:
-        _LOGGER.warning("jura_connect XML data unavailable; skipping brew button setup")
-        return
-    definition = load_definition(machine_type, base_dir=base_dir)
-    if definition is None:
-        _LOGGER.warning("no machine definition for %s; skipping brew button setup", machine_type)
-        return
-
-    entities = [JuraBrewButton(coordinator, config_entry, product) for product in definition.products]
-    async_add_entities(entities)
+    async_add_entities([JuraBrewButton(coordinator, config_entry)])
 
 
 class JuraBrewButton(JuraEntity, ButtonEntity):
-    """Brews one product. Pressing this **physically brews a drink.**
+    """Brews the currently-selected product. **Pressing this physically brews.**
 
-    Reads the staged strength/water/temperature from
-    ``coordinator.brew_params`` (falling back to the XML defaults baked
-    into :func:`build_start_command`) and dispatches the library ``brew``
-    command with the recipe payload (the 16-byte hex, *without* the
-    ``@TP:`` prefix — the library re-adds it).
+    Resolves ``coordinator.brew_selection`` to a product and parameter set,
+    encodes the recipe (the 16-byte hex *without* the ``@TP:`` prefix — the
+    library re-adds it) and dispatches the ``brew`` command.
     """
 
-    def __init__(self, coordinator: JuraCoordinator, config_entry: ConfigEntry, product: ProductDef) -> None:
+    def __init__(self, coordinator: JuraCoordinator, config_entry: ConfigEntry) -> None:
         super().__init__(coordinator, config_entry)
-        self._product = product
-        self._attr_name = f"Brew {product.name}"
-        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.code}"
+        self._attr_name = "Brew"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew"
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.selected_product() is not None
 
     async def async_press(self) -> None:
-        params = self.coordinator.brew_params.get(self._product.code, {})
+        product = self.coordinator.selected_product()
+        if product is None:
+            return
+        selection = self.coordinator.brew_selection
         payload = build_start_command(
-            self._product,
-            strength=params.get("strength"),
-            water_ml=params.get("water_ml"),
-            temp=params.get("temp"),
+            product,
+            strength=selection.get("strength"),
+            water_ml=selection.get("water_ml"),
+            temp=selection.get("temp"),
         )
         recipe = payload.removeprefix("@TP:")
         await self.coordinator.run_command("brew", [recipe], allow_destructive=True)

--- a/custom_components/jura/button.py
+++ b/custom_components/jura/button.py
@@ -1,0 +1,80 @@
+"""Button platform: one "Brew <product>" button per machine product.
+
+Pressing a button PHYSICALLY brews a drink on the machine. The button
+encodes the full 16-byte ``@TP:`` start command from the machine's
+product definition (sourced from the ``jura_connect`` package data) and
+the per-product parameters staged on the coordinator by the brew
+strength/water/temperature entities, then dispatches the library's
+``brew`` command (with ``allow_destructive=True`` — pressing the button
+is the explicit opt-in).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .brew import ProductDef, build_start_command, jura_connect_xml_dir, load_definition
+from .const import CONF_MACHINE_TYPE, DOMAIN
+from .coordinator import JuraCoordinator
+from .entity import JuraEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: JuraCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    machine_type = config_entry.data.get(CONF_MACHINE_TYPE)
+    if not machine_type:
+        return
+
+    # Products come from jura_connect's bundled machine-definition XMLs.
+    # A missing package / profile is a configuration / version-skew issue —
+    # log and skip rather than crash the integration (mirrors select.py).
+    base_dir = jura_connect_xml_dir()
+    if base_dir is None:
+        _LOGGER.warning("jura_connect XML data unavailable; skipping brew button setup")
+        return
+    definition = load_definition(machine_type, base_dir=base_dir)
+    if definition is None:
+        _LOGGER.warning("no machine definition for %s; skipping brew button setup", machine_type)
+        return
+
+    entities = [JuraBrewButton(coordinator, config_entry, product) for product in definition.products]
+    async_add_entities(entities)
+
+
+class JuraBrewButton(JuraEntity, ButtonEntity):
+    """Brews one product. Pressing this **physically brews a drink.**
+
+    Reads the staged strength/water/temperature from
+    ``coordinator.brew_params`` (falling back to the XML defaults baked
+    into :func:`build_start_command`) and dispatches the library ``brew``
+    command with the recipe payload (the 16-byte hex, *without* the
+    ``@TP:`` prefix — the library re-adds it).
+    """
+
+    def __init__(self, coordinator: JuraCoordinator, config_entry: ConfigEntry, product: ProductDef) -> None:
+        super().__init__(coordinator, config_entry)
+        self._product = product
+        self._attr_name = f"Brew {product.name}"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.code}"
+
+    async def async_press(self) -> None:
+        params = self.coordinator.brew_params.get(self._product.code, {})
+        payload = build_start_command(
+            self._product,
+            strength=params.get("strength"),
+            water_ml=params.get("water_ml"),
+            temp=params.get("temp"),
+        )
+        recipe = payload.removeprefix("@TP:")
+        await self.coordinator.run_command("brew", [recipe], allow_destructive=True)

--- a/custom_components/jura/const.py
+++ b/custom_components/jura/const.py
@@ -152,3 +152,11 @@ PERCENT_KEYS: tuple[str, ...] = (
 
 # 0xFF is the library's sentinel for "this percent indicator is absent / unknown".
 PERCENT_ABSENT_SENTINEL = 0xFF
+
+# User-facing label overrides (display only — the data keys stay exactly as the
+# library emits them, e.g. snapshot.counters["decalc"]). JURA's German-ism
+# "decalc" is shown to the user as the English "descale".
+FRIENDLY_LABELS: dict[str, str] = {
+    "decalc": "descale",
+    "decalc_alert": "descale_alert",
+}

--- a/custom_components/jura/coordinator.py
+++ b/custom_components/jura/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .backends.base import JuraAuthError, JuraBackend, JuraBackendError, MachineSnapshot
 from .backends.jura import JuraConnectBackend
+from .brew import MachineDefinition, ProductDef, jura_connect_xml_dir, load_definition
 from .const import (
     CONF_AUTH_HASH,
     CONF_CONN_ID,
@@ -49,12 +50,52 @@ class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
             config_entry=config_entry,
         )
         self.backend: JuraBackend = backend or self._build_backend(config_entry)
-        # Staged "next brew" parameters per product code, e.g.
-        # ``{"30": {"strength": 8, "water_ml": 90, "temp": 2}}``. The brew
-        # parameter entities (select/number) write here; the brew button
-        # reads from here. Purely local — nothing is sent to the machine
-        # until the user presses the button or calls the brew service.
-        self.brew_params: dict[str, dict[str, int]] = {}
+        # The machine's brewable-product table (from jura_connect's bundled
+        # XMLs), loaded once so the brew control-panel entities and the brew
+        # button can resolve products + argument ranges without re-parsing.
+        self.brew_definition: MachineDefinition | None = self._load_brew_definition(config_entry)
+        # The single staged "next brew" selection shared by the whole machine.
+        # ``product`` is a product Code; ``None`` for a parameter means "use
+        # the machine's own default for the selected product". The brew
+        # control-panel selects write here; the brew button reads from here.
+        # Purely local — nothing is sent to the machine until the user presses
+        # the button or calls the brew service.
+        self.brew_selection: dict[str, int | str | None] = {
+            "product": None,
+            "strength": None,
+            "water_ml": None,
+            "temp": None,
+        }
+        if self.brew_definition is not None and self.brew_definition.products:
+            self.brew_selection["product"] = self.brew_definition.products[0].code
+
+    @staticmethod
+    def _load_brew_definition(config_entry: ConfigEntry) -> MachineDefinition | None:
+        """Resolve + parse the machine's product definition, or ``None``.
+
+        A missing ``jura_connect`` package / unknown machine type is a
+        configuration / version-skew condition, not a hard error: the brew
+        control panel simply isn't created.
+        """
+        machine_type = config_entry.data.get(CONF_MACHINE_TYPE)
+        if not machine_type:
+            return None
+        base_dir = jura_connect_xml_dir()
+        if base_dir is None:
+            return None
+        return load_definition(machine_type, base_dir=base_dir)
+
+    def selected_product(self) -> ProductDef | None:
+        """Return the currently-selected :class:`ProductDef`, or ``None``."""
+        if self.brew_definition is None:
+            return None
+        code = self.brew_selection.get("product")
+        if code is None:
+            return None
+        for product in self.brew_definition.products:
+            if product.code == code:
+                return product
+        return None
 
     @staticmethod
     def _build_backend(config_entry: ConfigEntry) -> JuraBackend:

--- a/custom_components/jura/coordinator.py
+++ b/custom_components/jura/coordinator.py
@@ -49,6 +49,12 @@ class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
             config_entry=config_entry,
         )
         self.backend: JuraBackend = backend or self._build_backend(config_entry)
+        # Staged "next brew" parameters per product code, e.g.
+        # ``{"30": {"strength": 8, "water_ml": 90, "temp": 2}}``. The brew
+        # parameter entities (select/number) write here; the brew button
+        # reads from here. Purely local — nothing is sent to the machine
+        # until the user presses the button or calls the brew service.
+        self.brew_params: dict[str, dict[str, int]] = {}
 
     @staticmethod
     def _build_backend(config_entry: ConfigEntry) -> JuraBackend:

--- a/custom_components/jura/coordinator.py
+++ b/custom_components/jura/coordinator.py
@@ -10,11 +10,19 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .backends.base import JuraAuthError, JuraBackend, JuraBackendError, MachineSnapshot
 from .backends.jura import JuraConnectBackend
-from .brew import MachineDefinition, ProductDef, jura_connect_xml_dir, load_definition
+from .brew import (
+    MachineDefinition,
+    ProductDef,
+    jura_connect_xml_dir,
+    load_definition,
+    remember_param,
+    selection_for_product,
+)
 from .const import (
     CONF_AUTH_HASH,
     CONF_CONN_ID,
@@ -28,6 +36,12 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Persisted brew-preferences store. Bump the version only on an incompatible
+# on-disk schema change. Saves are debounced by this many seconds so a flurry
+# of select changes collapses into a single write.
+BREW_PREFS_STORAGE_VERSION = 1
+BREW_PREFS_SAVE_DELAY = 1.0
 
 
 class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
@@ -55,8 +69,11 @@ class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
         # button can resolve products + argument ranges without re-parsing.
         self.brew_definition: MachineDefinition | None = self._load_brew_definition(config_entry)
         # The single staged "next brew" selection shared by the whole machine.
-        # ``product`` is a product Code; ``None`` for a parameter means "use
-        # the machine's own default for the selected product". The brew
+        # ``product`` is a product Code; ``None`` for a parameter means "Factory
+        # Default" — send that product's XML/factory default value (i.e. pass
+        # ``None`` to ``build_start_command``). It does NOT mean "use whatever
+        # the machine currently has stored": JURA WiFi exposes no such
+        # mechanism, so an explicit, clamped value is always sent. The brew
         # control-panel selects write here; the brew button reads from here.
         # Purely local — nothing is sent to the machine until the user presses
         # the button or calls the brew service.
@@ -68,6 +85,12 @@ class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
         }
         if self.brew_definition is not None and self.brew_definition.products:
             self.brew_selection["product"] = self.brew_definition.products[0].code
+        # Persistent per-product brew preferences: product Code (hex) ->
+        # {"strength"|"water_ml"|"temp": int | None}, where ``None`` == Factory
+        # Default. Loaded from disk by ``async_load_brew_prefs`` at setup and
+        # written back (debounced) by ``save_brew_prefs``.
+        self.brew_prefs: dict[str, dict[str, int | None]] = {}
+        self._brew_prefs_store: Store | None = None
 
     @staticmethod
     def _load_brew_definition(config_entry: ConfigEntry) -> MachineDefinition | None:
@@ -96,6 +119,56 @@ class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
             if product.code == code:
                 return product
         return None
+
+    # --- persistent per-product brew preferences -------------------------
+    def _brew_prefs_storage_key(self) -> str:
+        return f"{DOMAIN}.brew_prefs.{self.config_entry.entry_id}"
+
+    async def async_load_brew_prefs(self) -> None:
+        """Wire the Store and load persisted brew prefs into ``brew_prefs``.
+
+        Called once at config-entry setup. After loading, the staged selection
+        is re-hydrated from the currently-selected (first) product's prefs so a
+        fresh Home Assistant start shows remembered values rather than blanks.
+        """
+        self._brew_prefs_store = Store(self.hass, BREW_PREFS_STORAGE_VERSION, self._brew_prefs_storage_key())
+        data = await self._brew_prefs_store.async_load()
+        self.brew_prefs = data or {}
+        code = self.brew_selection.get("product")
+        if code is not None:
+            self.brew_selection.update(selection_for_product(self.brew_prefs, code))
+
+    async def save_brew_prefs(self) -> None:
+        """Schedule a debounced write of ``brew_prefs`` to disk.
+
+        No-op until ``async_load_brew_prefs`` has wired the Store. The data
+        callback returns the live dict so the most recent edits are captured
+        when the delayed save fires.
+        """
+        if self._brew_prefs_store is None:
+            return
+        self._brew_prefs_store.async_delay_save(lambda: self.brew_prefs, BREW_PREFS_SAVE_DELAY)
+
+    def select_brew_product(self, code: str) -> None:
+        """Make ``code`` the staged product, hydrating its saved prefs.
+
+        Each parameter is loaded from the product's saved prefs (missing ->
+        ``None`` == Factory Default), replacing whatever was staged for the
+        previous product.
+        """
+        self.brew_selection.update(selection_for_product(self.brew_prefs, code))
+
+    def set_brew_param(self, param: str, value: int | None) -> None:
+        """Stage ``value`` for ``param`` and remember it for the current product.
+
+        ``value`` is ``None`` for Factory Default, else the chosen value. Both
+        the live selection and the persisted prefs for the current product are
+        updated; callers schedule the disk write via :meth:`save_brew_prefs`.
+        """
+        self.brew_selection[param] = value
+        code = self.brew_selection.get("product")
+        if code is not None:
+            remember_param(self.brew_prefs, str(code), param, value)
 
     @staticmethod
     def _build_backend(config_entry: ConfigEntry) -> JuraBackend:

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
     "requirements": ["jura_connect>=0.9.4"],
-    "version": "0.10.0"
+    "version": "0.10.1"
 }

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
     "requirements": ["jura_connect>=0.9.4"],
-    "version": "0.9.0"
+    "version": "0.10.0"
 }

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
     "requirements": ["jura_connect>=0.9.4"],
-    "version": "0.8.0"
+    "version": "0.9.0"
 }

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
     "requirements": ["jura_connect>=0.9.4"],
-    "version": "0.7.4"
+    "version": "0.8.0"
 }

--- a/custom_components/jura/number.py
+++ b/custom_components/jura/number.py
@@ -2,6 +2,10 @@
 
 Covers SettingDef kind ``step_slider`` (Hardness on EF1091, etc.) —
 integer-valued range with min/max/step from the profile XML.
+
+Brew water amount is *not* a number here: it lives on the ``select``
+platform (``BrewWaterSelect``) so it can offer a "Machine Default"
+option alongside the millilitre choices.
 """
 
 from __future__ import annotations
@@ -14,7 +18,6 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .brew import ProductArg, ProductDef, jura_connect_xml_dir, load_definition
 from .const import CONF_MACHINE_TYPE, DOMAIN
 from .coordinator import JuraCoordinator
 from .entity import JuraEntity
@@ -32,10 +35,7 @@ async def async_setup_entry(
     if not machine_type:
         return
 
-    entities: list[NumberEntity] = []
-    entities.extend(_setting_number_entities(coordinator, config_entry, machine_type))
-    entities.extend(_brew_water_entities(coordinator, config_entry, machine_type))
-    async_add_entities(entities)
+    async_add_entities(_setting_number_entities(coordinator, config_entry, machine_type))
 
 
 def _setting_number_entities(
@@ -56,26 +56,6 @@ def _setting_number_entities(
     for setting in profile.settings:
         if setting.kind == "step_slider":
             entities.append(SettingNumberEntity(coordinator, config_entry, setting))
-    return entities
-
-
-def _brew_water_entities(
-    coordinator: JuraCoordinator, config_entry: ConfigEntry, machine_type: str
-) -> list[NumberEntity]:
-    """Build per-product water-amount numbers from the machine definition."""
-    base_dir = jura_connect_xml_dir()
-    if base_dir is None:
-        return []
-    definition = load_definition(machine_type, base_dir=base_dir)
-    if definition is None:
-        _LOGGER.warning("no machine definition for %s; skipping brew water numbers", machine_type)
-        return []
-
-    entities: list[NumberEntity] = []
-    for product in definition.products:
-        arg = product.arg("WATER_AMOUNT")
-        if arg is not None:
-            entities.append(BrewWaterNumber(coordinator, config_entry, product, arg))
     return entities
 
 
@@ -115,43 +95,3 @@ class SettingNumberEntity(JuraEntity, NumberEntity):
         n = int(value)
         width = len(self._setting.mask) if self._setting.mask else 2
         await self.coordinator.write_setting(self._setting.name, f"{n:0{width}X}")
-
-
-class BrewWaterNumber(JuraEntity, NumberEntity):
-    """Stages the per-product water amount (millilitres) for the next brew.
-
-    A CONFIG entity: it holds the ml value to use on the *next* brew of its
-    product and never talks to the machine. The value lives on
-    ``coordinator.brew_params[product.code]["water_ml"]`` so the brew button
-    can read it; min/max/step/default come from the product's XML argument.
-    """
-
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_mode = "slider"
-    _attr_native_unit_of_measurement = "mL"
-
-    def __init__(
-        self,
-        coordinator: JuraCoordinator,
-        config_entry: ConfigEntry,
-        product: ProductDef,
-        arg: ProductArg,
-    ) -> None:
-        super().__init__(coordinator, config_entry)
-        self._product = product
-        self._arg = arg
-        self._attr_name = f"{product.name} water"
-        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.code}_water_ml"
-        self._attr_native_min_value = float(arg.min if arg.min is not None else 0)
-        self._attr_native_max_value = float(arg.max if arg.max is not None else 0xFF)
-        self._attr_native_step = float(arg.step or 1)
-        coordinator.brew_params.setdefault(product.code, {}).setdefault("water_ml", arg.default)
-
-    @property
-    def native_value(self) -> float | None:
-        value = self.coordinator.brew_params.get(self._product.code, {}).get("water_ml", self._arg.default)
-        return float(value)
-
-    async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.brew_params.setdefault(self._product.code, {})["water_ml"] = int(value)
-        self.async_write_ha_state()

--- a/custom_components/jura/number.py
+++ b/custom_components/jura/number.py
@@ -4,7 +4,7 @@ Covers SettingDef kind ``step_slider`` (Hardness on EF1091, etc.) —
 integer-valued range with min/max/step from the profile XML.
 
 Brew water amount is *not* a number here: it lives on the ``select``
-platform (``BrewWaterSelect``) so it can offer a "Machine Default"
+platform (``BrewWaterSelect``) so it can offer a "Factory Default"
 option alongside the millilitre choices.
 """
 

--- a/custom_components/jura/number.py
+++ b/custom_components/jura/number.py
@@ -14,6 +14,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .brew import ProductArg, ProductDef, jura_connect_xml_dir, load_definition
 from .const import CONF_MACHINE_TYPE, DOMAIN
 from .coordinator import JuraCoordinator
 from .entity import JuraEntity
@@ -31,21 +32,51 @@ async def async_setup_entry(
     if not machine_type:
         return
 
+    entities: list[NumberEntity] = []
+    entities.extend(_setting_number_entities(coordinator, config_entry, machine_type))
+    entities.extend(_brew_water_entities(coordinator, config_entry, machine_type))
+    async_add_entities(entities)
+
+
+def _setting_number_entities(
+    coordinator: JuraCoordinator, config_entry: ConfigEntry, machine_type: str
+) -> list[NumberEntity]:
+    """Build the writable step_slider machine-setting numbers (e.g. hardness)."""
     try:
         from jura_connect import load_profile
     except ImportError:  # pragma: no cover
-        return
+        return []
     try:
         profile = load_profile(machine_type)
     except KeyError:
-        _LOGGER.warning("no profile for machine_type %s; skipping number setup", machine_type)
-        return
+        _LOGGER.warning("no profile for machine_type %s; skipping setting numbers", machine_type)
+        return []
 
     entities: list[NumberEntity] = []
     for setting in profile.settings:
         if setting.kind == "step_slider":
             entities.append(SettingNumberEntity(coordinator, config_entry, setting))
-    async_add_entities(entities)
+    return entities
+
+
+def _brew_water_entities(
+    coordinator: JuraCoordinator, config_entry: ConfigEntry, machine_type: str
+) -> list[NumberEntity]:
+    """Build per-product water-amount numbers from the machine definition."""
+    base_dir = jura_connect_xml_dir()
+    if base_dir is None:
+        return []
+    definition = load_definition(machine_type, base_dir=base_dir)
+    if definition is None:
+        _LOGGER.warning("no machine definition for %s; skipping brew water numbers", machine_type)
+        return []
+
+    entities: list[NumberEntity] = []
+    for product in definition.products:
+        arg = product.arg("WATER_AMOUNT")
+        if arg is not None:
+            entities.append(BrewWaterNumber(coordinator, config_entry, product, arg))
+    return entities
 
 
 class SettingNumberEntity(JuraEntity, NumberEntity):
@@ -84,3 +115,43 @@ class SettingNumberEntity(JuraEntity, NumberEntity):
         n = int(value)
         width = len(self._setting.mask) if self._setting.mask else 2
         await self.coordinator.write_setting(self._setting.name, f"{n:0{width}X}")
+
+
+class BrewWaterNumber(JuraEntity, NumberEntity):
+    """Stages the per-product water amount (millilitres) for the next brew.
+
+    A CONFIG entity: it holds the ml value to use on the *next* brew of its
+    product and never talks to the machine. The value lives on
+    ``coordinator.brew_params[product.code]["water_ml"]`` so the brew button
+    can read it; min/max/step/default come from the product's XML argument.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = "slider"
+    _attr_native_unit_of_measurement = "mL"
+
+    def __init__(
+        self,
+        coordinator: JuraCoordinator,
+        config_entry: ConfigEntry,
+        product: ProductDef,
+        arg: ProductArg,
+    ) -> None:
+        super().__init__(coordinator, config_entry)
+        self._product = product
+        self._arg = arg
+        self._attr_name = f"{product.name} water"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.code}_water_ml"
+        self._attr_native_min_value = float(arg.min if arg.min is not None else 0)
+        self._attr_native_max_value = float(arg.max if arg.max is not None else 0xFF)
+        self._attr_native_step = float(arg.step or 1)
+        coordinator.brew_params.setdefault(product.code, {}).setdefault("water_ml", arg.default)
+
+    @property
+    def native_value(self) -> float | None:
+        value = self.coordinator.brew_params.get(self._product.code, {}).get("water_ml", self._arg.default)
+        return float(value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        self.coordinator.brew_params.setdefault(self._product.code, {})["water_ml"] = int(value)
+        self.async_write_ha_state()

--- a/custom_components/jura/select.py
+++ b/custom_components/jura/select.py
@@ -8,11 +8,16 @@ Two families of selects live here:
   platform instead.
 * **Brew control panel** — a small, machine-wide set that stages the
   *next* brew: a product picker plus strength / water / temperature
-  selects. Each parameter select carries a ``"Machine Default"`` option
-  (meaning "let the machine use the selected product's own default") and
+  selects. Each parameter select carries a ``"Factory Default"`` option
+  (meaning "send that product's XML/factory default value" — i.e. pass
+  ``None`` to ``build_start_command``; it does NOT mean "use the machine's
+  own configured setting", which JURA WiFi has no mechanism for) and
   recomputes its options from whichever product is currently selected.
-  None of them talk to the machine; the brew button reads the staged
-  ``coordinator.brew_selection`` and encodes the ``@TP:`` start command.
+  Per-product choices persist across restarts (``coordinator.brew_prefs``):
+  picking a product hydrates the param selects from its saved prefs, and
+  editing a param remembers it for that product. None of them talk to the
+  machine; the brew button reads the staged ``coordinator.brew_selection``
+  and encodes the ``@TP:`` start command.
 """
 
 from __future__ import annotations
@@ -34,8 +39,11 @@ _LOGGER = logging.getLogger(__name__)
 
 SELECT_KINDS = {"switch", "combobox", "item_slider"}
 
-# Sentinel option meaning "don't override — use the product's machine default".
-MACHINE_DEFAULT = "Machine Default"
+# Sentinel option meaning "don't override — send the product's XML/factory
+# default value" (i.e. pass ``None`` to ``build_start_command``). This is NOT
+# "use the machine's own stored setting": JURA WiFi exposes no such mechanism,
+# so an explicit, clamped value is always sent.
+FACTORY_DEFAULT = "Factory Default"
 
 
 async def async_setup_entry(
@@ -141,11 +149,11 @@ class SettingSelectEntity(JuraEntity, SelectEntity):
 class BrewProductSelect(JuraEntity, SelectEntity):
     """Picks which product the brew button (and parameter selects) act on.
 
-    Selecting a product stores its Code on ``coordinator.brew_selection``
-    and resets strength/water/temperature back to "Machine Default" — the
-    previous parameter values rarely make sense for a different drink. It
-    then asks the coordinator to refresh listeners so the dependent
-    parameter selects re-render their (product-specific) options.
+    Selecting a product makes its Code the staged product and hydrates
+    strength/water/temperature from that product's *saved preferences*
+    (each missing param falls back to "Factory Default"). It then asks the
+    coordinator to refresh listeners so the dependent parameter selects
+    re-render their (product-specific) options and loaded values.
     """
 
     _attr_entity_category = EntityCategory.CONFIG
@@ -177,12 +185,9 @@ class BrewProductSelect(JuraEntity, SelectEntity):
             return
         for product in definition.products:
             if product.name == option:
-                self.coordinator.brew_selection.update(
-                    product=product.code,
-                    strength=None,
-                    water_ml=None,
-                    temp=None,
-                )
+                # Make this the current product and load its saved prefs into
+                # the staged selection.
+                self.coordinator.select_brew_product(product.code)
                 # Refresh the whole panel: the parameter selects' options and
                 # values depend on the now-current product.
                 self.coordinator.async_update_listeners()
@@ -193,10 +198,12 @@ class _BrewParamSelect(JuraEntity, SelectEntity):
     """Base for a brew parameter select bound to the *currently-selected* product.
 
     Subclasses bind to one product argument kind (strength / water /
-    temperature). Options always lead with :data:`MACHINE_DEFAULT`; the
+    temperature). Options always lead with :data:`FACTORY_DEFAULT`; the
     value lives on ``coordinator.brew_selection[<key>]`` where ``None``
-    means "machine default". The select is unavailable while the selected
-    product doesn't expose the argument.
+    means "Factory Default" (send the product's XML default). Changing the
+    value also remembers it for the current product (``coordinator.brew_prefs``)
+    and schedules a persistent save. The select is unavailable while the
+    selected product doesn't expose the argument.
     """
 
     _attr_entity_category = EntityCategory.CONFIG
@@ -221,8 +228,8 @@ class _BrewParamSelect(JuraEntity, SelectEntity):
     def options(self) -> list[str]:
         arg = self._arg()
         if arg is None:
-            return [MACHINE_DEFAULT]
-        return [MACHINE_DEFAULT, *self._value_options(arg)]
+            return [FACTORY_DEFAULT]
+        return [FACTORY_DEFAULT, *self._value_options(arg)]
 
     @property
     def current_option(self) -> str | None:
@@ -231,21 +238,22 @@ class _BrewParamSelect(JuraEntity, SelectEntity):
             return None
         value = self.coordinator.brew_selection.get(self._selection_key)
         if value is None:
-            return MACHINE_DEFAULT
+            return FACTORY_DEFAULT
         return self._option_for_value(arg, value)
 
     async def async_select_option(self, option: str) -> None:
-        if option == MACHINE_DEFAULT:
-            self.coordinator.brew_selection[self._selection_key] = None
-            self.async_write_ha_state()
-            return
-        arg = self._arg()
-        if arg is None:
-            return
-        value = self._value_for_option(arg, option)
-        if value is None:
-            return
-        self.coordinator.brew_selection[self._selection_key] = value
+        if option == FACTORY_DEFAULT:
+            value: int | None = None
+        else:
+            arg = self._arg()
+            if arg is None:
+                return
+            value = self._value_for_option(arg, option)
+            if value is None:
+                return
+        # Stage + remember for the current product, then persist (debounced).
+        self.coordinator.set_brew_param(self._selection_key, value)
+        await self.coordinator.save_brew_prefs()
         self.async_write_ha_state()
 
     # --- per-kind value <-> option mapping -------------------------------
@@ -279,7 +287,7 @@ class _ItemBrewSelect(_BrewParamSelect):
 
 
 class BrewStrengthSelect(_ItemBrewSelect):
-    """Coffee strength for the next brew (e.g. 1..10), or machine default."""
+    """Coffee strength for the next brew (e.g. 1..10), or Factory Default."""
 
     _arg_kind = "COFFEE_STRENGTH"
     _selection_key = "strength"
@@ -287,7 +295,7 @@ class BrewStrengthSelect(_ItemBrewSelect):
 
 
 class BrewTempSelect(_ItemBrewSelect):
-    """Temperature for the next brew (e.g. Low/Normal/High), or machine default."""
+    """Temperature for the next brew (e.g. Low/Normal/High), or Factory Default."""
 
     _arg_kind = "TEMPERATURE"
     _selection_key = "temp"
@@ -295,9 +303,9 @@ class BrewTempSelect(_ItemBrewSelect):
 
 
 class BrewWaterSelect(_BrewParamSelect):
-    """Water amount (mL) for the next brew, or machine default.
+    """Water amount (mL) for the next brew, or Factory Default.
 
-    A select (rather than a number) so it can carry the ``Machine Default``
+    A select (rather than a number) so it can carry the ``Factory Default``
     sentinel; its options are the product's ``min..max`` range in ``step``
     increments.
     """

--- a/custom_components/jura/select.py
+++ b/custom_components/jura/select.py
@@ -16,6 +16,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .brew import ProductArg, ProductDef, jura_connect_xml_dir, load_definition
 from .const import CONF_MACHINE_TYPE, DOMAIN
 from .coordinator import JuraCoordinator
 from .entity import JuraEntity
@@ -23,6 +24,13 @@ from .entity import JuraEntity
 _LOGGER = logging.getLogger(__name__)
 
 SELECT_KINDS = {"switch", "combobox", "item_slider"}
+
+# Brew-parameter SelectEntity kinds: which product argument maps to which
+# coordinator.brew_params key and entity-name suffix.
+_BREW_SELECT_PARAMS = {
+    "COFFEE_STRENGTH": ("strength", "strength"),
+    "TEMPERATURE": ("temp", "temperature"),
+}
 
 
 async def async_setup_entry(
@@ -35,18 +43,29 @@ async def async_setup_entry(
     if not machine_type:
         return
 
-    # Load the profile to enumerate settings. Failing to load is a
-    # configuration / version-skew error — log and bail rather than
-    # crashing the integration.
+    entities: list[SelectEntity] = []
+    entities.extend(_setting_select_entities(coordinator, config_entry, machine_type))
+    entities.extend(_brew_param_select_entities(coordinator, config_entry, machine_type))
+    async_add_entities(entities)
+
+
+def _setting_select_entities(
+    coordinator: JuraCoordinator, config_entry: ConfigEntry, machine_type: str
+) -> list[SelectEntity]:
+    """Build the writable machine-setting selects (combobox/switch/item_slider).
+
+    Failing to load the profile is a configuration / version-skew error —
+    log and skip rather than crashing the integration.
+    """
     try:
         from jura_connect import load_profile
     except ImportError:  # pragma: no cover
-        return
+        return []
     try:
         profile = load_profile(machine_type)
     except KeyError:
-        _LOGGER.warning("no profile for machine_type %s; skipping select setup", machine_type)
-        return
+        _LOGGER.warning("no profile for machine_type %s; skipping setting selects", machine_type)
+        return []
 
     entities: list[SelectEntity] = []
     for setting in profile.settings:
@@ -55,7 +74,28 @@ async def async_setup_entry(
         if not setting.items:
             continue
         entities.append(SettingSelectEntity(coordinator, config_entry, setting))
-    async_add_entities(entities)
+    return entities
+
+
+def _brew_param_select_entities(
+    coordinator: JuraCoordinator, config_entry: ConfigEntry, machine_type: str
+) -> list[SelectEntity]:
+    """Build per-product strength + temperature selects from the machine def."""
+    base_dir = jura_connect_xml_dir()
+    if base_dir is None:
+        return []
+    definition = load_definition(machine_type, base_dir=base_dir)
+    if definition is None:
+        _LOGGER.warning("no machine definition for %s; skipping brew param selects", machine_type)
+        return []
+
+    entities: list[SelectEntity] = []
+    for product in definition.products:
+        for kind in _BREW_SELECT_PARAMS:
+            arg = product.arg(kind)
+            if arg is not None and arg.items:
+                entities.append(BrewParamSelect(coordinator, config_entry, product, arg))
+    return entities
 
 
 class SettingSelectEntity(JuraEntity, SelectEntity):
@@ -91,3 +131,45 @@ class SettingSelectEntity(JuraEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         await self.coordinator.write_setting(self._setting.name, option)
+
+
+class BrewParamSelect(JuraEntity, SelectEntity):
+    """Stages a per-product brew parameter (coffee strength or temperature).
+
+    A CONFIG entity that holds the value to use on the *next* brew of its
+    product; it never talks to the machine. The chosen byte value lives on
+    ``coordinator.brew_params[product.code]`` so the brew button can read
+    it. Options and the seeded default come from the product's XML argument.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: JuraCoordinator,
+        config_entry: ConfigEntry,
+        product: ProductDef,
+        arg: ProductArg,
+    ) -> None:
+        super().__init__(coordinator, config_entry)
+        self._product = product
+        self._arg = arg
+        self._param_key, label = _BREW_SELECT_PARAMS[arg.kind]
+        self._value_by_name = {name: value for name, value in arg.items}
+        self._name_by_value = {value: name for name, value in arg.items}
+        self._attr_name = f"{product.name} {label}"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.code}_{self._param_key}"
+        self._attr_options = [name for name, _ in arg.items]
+        coordinator.brew_params.setdefault(product.code, {}).setdefault(self._param_key, arg.default)
+
+    @property
+    def current_option(self) -> str | None:
+        value = self.coordinator.brew_params.get(self._product.code, {}).get(self._param_key, self._arg.default)
+        return self._name_by_value.get(value)
+
+    async def async_select_option(self, option: str) -> None:
+        value = self._value_by_name.get(option)
+        if value is None:
+            return
+        self.coordinator.brew_params.setdefault(self._product.code, {})[self._param_key] = value
+        self.async_write_ha_state()

--- a/custom_components/jura/select.py
+++ b/custom_components/jura/select.py
@@ -1,9 +1,18 @@
-"""Select platform: one dropdown per pick-from-N machine setting.
+"""Select platform: machine-setting dropdowns + the brew control panel.
 
-Covers SettingDef kinds ``switch``, ``combobox`` and ``item_slider`` —
-all of which present a fixed list of named choices on the machine.
-``step_slider`` settings (hardness) are handled by the ``number``
-platform instead.
+Two families of selects live here:
+
+* **Setting selects** — one dropdown per pick-from-N machine setting
+  (SettingDef kinds ``switch``, ``combobox`` and ``item_slider``).
+  ``step_slider`` settings (hardness) are handled by the ``number``
+  platform instead.
+* **Brew control panel** — a small, machine-wide set that stages the
+  *next* brew: a product picker plus strength / water / temperature
+  selects. Each parameter select carries a ``"Machine Default"`` option
+  (meaning "let the machine use the selected product's own default") and
+  recomputes its options from whichever product is currently selected.
+  None of them talk to the machine; the brew button reads the staged
+  ``coordinator.brew_selection`` and encodes the ``@TP:`` start command.
 """
 
 from __future__ import annotations
@@ -16,7 +25,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .brew import ProductArg, ProductDef, jura_connect_xml_dir, load_definition
+from .brew import ProductArg
 from .const import CONF_MACHINE_TYPE, DOMAIN
 from .coordinator import JuraCoordinator
 from .entity import JuraEntity
@@ -25,12 +34,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SELECT_KINDS = {"switch", "combobox", "item_slider"}
 
-# Brew-parameter SelectEntity kinds: which product argument maps to which
-# coordinator.brew_params key and entity-name suffix.
-_BREW_SELECT_PARAMS = {
-    "COFFEE_STRENGTH": ("strength", "strength"),
-    "TEMPERATURE": ("temp", "temperature"),
-}
+# Sentinel option meaning "don't override — use the product's machine default".
+MACHINE_DEFAULT = "Machine Default"
 
 
 async def async_setup_entry(
@@ -45,7 +50,7 @@ async def async_setup_entry(
 
     entities: list[SelectEntity] = []
     entities.extend(_setting_select_entities(coordinator, config_entry, machine_type))
-    entities.extend(_brew_param_select_entities(coordinator, config_entry, machine_type))
+    entities.extend(_brew_select_entities(coordinator, config_entry))
     async_add_entities(entities)
 
 
@@ -77,24 +82,24 @@ def _setting_select_entities(
     return entities
 
 
-def _brew_param_select_entities(
-    coordinator: JuraCoordinator, config_entry: ConfigEntry, machine_type: str
-) -> list[SelectEntity]:
-    """Build per-product strength + temperature selects from the machine def."""
-    base_dir = jura_connect_xml_dir()
-    if base_dir is None:
-        return []
-    definition = load_definition(machine_type, base_dir=base_dir)
-    if definition is None:
-        _LOGGER.warning("no machine definition for %s; skipping brew param selects", machine_type)
+def _brew_select_entities(coordinator: JuraCoordinator, config_entry: ConfigEntry) -> list[SelectEntity]:
+    """Build the machine-wide brew control panel (product + parameter selects).
+
+    A parameter select is created when *any* product on the machine exposes
+    that argument; it then toggles availability per the currently-selected
+    product (e.g. strength is unavailable while hot water is selected).
+    """
+    definition = coordinator.brew_definition
+    if definition is None or not definition.products:
         return []
 
-    entities: list[SelectEntity] = []
-    for product in definition.products:
-        for kind in _BREW_SELECT_PARAMS:
-            arg = product.arg(kind)
-            if arg is not None and arg.items:
-                entities.append(BrewParamSelect(coordinator, config_entry, product, arg))
+    entities: list[SelectEntity] = [BrewProductSelect(coordinator, config_entry)]
+    if any(product.arg("COFFEE_STRENGTH") for product in definition.products):
+        entities.append(BrewStrengthSelect(coordinator, config_entry))
+    if any(product.arg("WATER_AMOUNT") for product in definition.products):
+        entities.append(BrewWaterSelect(coordinator, config_entry))
+    if any(product.arg("TEMPERATURE") for product in definition.products):
+        entities.append(BrewTempSelect(coordinator, config_entry))
     return entities
 
 
@@ -133,43 +138,189 @@ class SettingSelectEntity(JuraEntity, SelectEntity):
         await self.coordinator.write_setting(self._setting.name, option)
 
 
-class BrewParamSelect(JuraEntity, SelectEntity):
-    """Stages a per-product brew parameter (coffee strength or temperature).
+class BrewProductSelect(JuraEntity, SelectEntity):
+    """Picks which product the brew button (and parameter selects) act on.
 
-    A CONFIG entity that holds the value to use on the *next* brew of its
-    product; it never talks to the machine. The chosen byte value lives on
-    ``coordinator.brew_params[product.code]`` so the brew button can read
-    it. Options and the seeded default come from the product's XML argument.
+    Selecting a product stores its Code on ``coordinator.brew_selection``
+    and resets strength/water/temperature back to "Machine Default" — the
+    previous parameter values rarely make sense for a different drink. It
+    then asks the coordinator to refresh listeners so the dependent
+    parameter selects re-render their (product-specific) options.
     """
 
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(
-        self,
-        coordinator: JuraCoordinator,
-        config_entry: ConfigEntry,
-        product: ProductDef,
-        arg: ProductArg,
-    ) -> None:
+    def __init__(self, coordinator: JuraCoordinator, config_entry: ConfigEntry) -> None:
         super().__init__(coordinator, config_entry)
-        self._product = product
-        self._arg = arg
-        self._param_key, label = _BREW_SELECT_PARAMS[arg.kind]
-        self._value_by_name = {name: value for name, value in arg.items}
-        self._name_by_value = {value: name for name, value in arg.items}
-        self._attr_name = f"{product.name} {label}"
-        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{product.code}_{self._param_key}"
-        self._attr_options = [name for name, _ in arg.items]
-        coordinator.brew_params.setdefault(product.code, {}).setdefault(self._param_key, arg.default)
+        self._attr_name = "Brew Product"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_product"
+
+    @property
+    def options(self) -> list[str]:
+        definition = self.coordinator.brew_definition
+        if definition is None:
+            return []
+        return [product.name for product in definition.products]
+
+    @property
+    def available(self) -> bool:
+        return bool(self.options)
 
     @property
     def current_option(self) -> str | None:
-        value = self.coordinator.brew_params.get(self._product.code, {}).get(self._param_key, self._arg.default)
-        return self._name_by_value.get(value)
+        product = self.coordinator.selected_product()
+        return product.name if product is not None else None
 
     async def async_select_option(self, option: str) -> None:
-        value = self._value_by_name.get(option)
+        definition = self.coordinator.brew_definition
+        if definition is None:
+            return
+        for product in definition.products:
+            if product.name == option:
+                self.coordinator.brew_selection.update(
+                    product=product.code,
+                    strength=None,
+                    water_ml=None,
+                    temp=None,
+                )
+                # Refresh the whole panel: the parameter selects' options and
+                # values depend on the now-current product.
+                self.coordinator.async_update_listeners()
+                return
+
+
+class _BrewParamSelect(JuraEntity, SelectEntity):
+    """Base for a brew parameter select bound to the *currently-selected* product.
+
+    Subclasses bind to one product argument kind (strength / water /
+    temperature). Options always lead with :data:`MACHINE_DEFAULT`; the
+    value lives on ``coordinator.brew_selection[<key>]`` where ``None``
+    means "machine default". The select is unavailable while the selected
+    product doesn't expose the argument.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _arg_kind: str
+    _selection_key: str
+    _name_suffix: str
+
+    def __init__(self, coordinator: JuraCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(coordinator, config_entry)
+        self._attr_name = f"Brew {self._name_suffix}"
+        self._attr_unique_id = f"{DOMAIN}_{self._slug}_brew_{self._selection_key}"
+
+    def _arg(self) -> ProductArg | None:
+        product = self.coordinator.selected_product()
+        return product.arg(self._arg_kind) if product is not None else None
+
+    @property
+    def available(self) -> bool:
+        return self._arg() is not None
+
+    @property
+    def options(self) -> list[str]:
+        arg = self._arg()
+        if arg is None:
+            return [MACHINE_DEFAULT]
+        return [MACHINE_DEFAULT, *self._value_options(arg)]
+
+    @property
+    def current_option(self) -> str | None:
+        arg = self._arg()
+        if arg is None:
+            return None
+        value = self.coordinator.brew_selection.get(self._selection_key)
+        if value is None:
+            return MACHINE_DEFAULT
+        return self._option_for_value(arg, value)
+
+    async def async_select_option(self, option: str) -> None:
+        if option == MACHINE_DEFAULT:
+            self.coordinator.brew_selection[self._selection_key] = None
+            self.async_write_ha_state()
+            return
+        arg = self._arg()
+        if arg is None:
+            return
+        value = self._value_for_option(arg, option)
         if value is None:
             return
-        self.coordinator.brew_params.setdefault(self._product.code, {})[self._param_key] = value
+        self.coordinator.brew_selection[self._selection_key] = value
         self.async_write_ha_state()
+
+    # --- per-kind value <-> option mapping -------------------------------
+    def _value_options(self, arg: ProductArg) -> list[str]:
+        raise NotImplementedError
+
+    def _value_for_option(self, arg: ProductArg, option: str) -> int | None:
+        raise NotImplementedError
+
+    def _option_for_value(self, arg: ProductArg, value: int) -> str | None:
+        raise NotImplementedError
+
+
+class _ItemBrewSelect(_BrewParamSelect):
+    """Brew parameter backed by a fixed list of named ITEMs (strength/temperature)."""
+
+    def _value_options(self, arg: ProductArg) -> list[str]:
+        return [name for name, _ in arg.items]
+
+    def _value_for_option(self, arg: ProductArg, option: str) -> int | None:
+        for name, value in arg.items:
+            if name == option:
+                return value
+        return None
+
+    def _option_for_value(self, arg: ProductArg, value: int) -> str | None:
+        for name, candidate in arg.items:
+            if candidate == value:
+                return name
+        return None
+
+
+class BrewStrengthSelect(_ItemBrewSelect):
+    """Coffee strength for the next brew (e.g. 1..10), or machine default."""
+
+    _arg_kind = "COFFEE_STRENGTH"
+    _selection_key = "strength"
+    _name_suffix = "Strength"
+
+
+class BrewTempSelect(_ItemBrewSelect):
+    """Temperature for the next brew (e.g. Low/Normal/High), or machine default."""
+
+    _arg_kind = "TEMPERATURE"
+    _selection_key = "temp"
+    _name_suffix = "Temperature"
+
+
+class BrewWaterSelect(_BrewParamSelect):
+    """Water amount (mL) for the next brew, or machine default.
+
+    A select (rather than a number) so it can carry the ``Machine Default``
+    sentinel; its options are the product's ``min..max`` range in ``step``
+    increments.
+    """
+
+    _arg_kind = "WATER_AMOUNT"
+    _selection_key = "water_ml"
+    _name_suffix = "Water"
+
+    @staticmethod
+    def _ml_range(arg: ProductArg) -> range:
+        low = arg.min if arg.min is not None else 0
+        high = arg.max if arg.max is not None else low
+        step = arg.step or 1
+        return range(low, high + 1, step)
+
+    def _value_options(self, arg: ProductArg) -> list[str]:
+        return [str(ml) for ml in self._ml_range(arg)]
+
+    def _value_for_option(self, arg: ProductArg, option: str) -> int | None:
+        try:
+            return int(option)
+        except ValueError:
+            return None
+
+    def _option_for_value(self, arg: ProductArg, value: int) -> str | None:
+        return str(value)

--- a/custom_components/jura/sensor.py
+++ b/custom_components/jura/sensor.py
@@ -14,6 +14,7 @@ from .backends.base import MachineSnapshot
 from .const import (
     COUNTER_KEYS,
     DOMAIN,
+    FRIENDLY_LABELS,
     PERCENT_KEYS,
     STATE_IDLE,
     STATE_PRIORITY,
@@ -89,7 +90,7 @@ class StateSensor(JuraEntity, SensorEntity):
 
 
 class CounterSensor(JuraEntity, SensorEntity):
-    """One maintenance counter (cleaning / decalc / filter / cappu / coffee rinse).
+    """One maintenance counter (cleaning / descale / filter / cappu / coffee rinse).
 
     Counters are diagnostic — they're useful for spotting "the machine has
     been cleaned 21 times" but not the day-to-day state most automations
@@ -110,7 +111,7 @@ class CounterSensor(JuraEntity, SensorEntity):
         self._key = key
         # The "Cycles" prefix groups all counter entities together when
         # the device card sorts entities alphabetically within a category.
-        self._attr_name = f"Cycles {key.replace('_', ' ')}"
+        self._attr_name = f"Cycles {FRIENDLY_LABELS.get(key, key).replace('_', ' ')}"
         self._attr_unique_id = f"{DOMAIN}_{self._slug}_counter_{key}"
 
     @property
@@ -140,7 +141,7 @@ class PercentSensor(JuraEntity, SensorEntity):
         super().__init__(coordinator, config_entry)
         self._key = key
         # "Service" prefix clusters the three percent indicators together.
-        self._attr_name = f"Service {key.replace('_', ' ')} level"
+        self._attr_name = f"Service {FRIENDLY_LABELS.get(key, key).replace('_', ' ')} level"
         self._attr_unique_id = f"{DOMAIN}_{self._slug}_percent_{key}"
 
     @property

--- a/custom_components/jura/services.yaml
+++ b/custom_components/jura/services.yaml
@@ -62,7 +62,7 @@ brew:
       name: Product
       description: >-
         Product name from the machine's product table (e.g. "Espresso").
-        See the "Brew <product>" buttons for the valid names on your model.
+        See the "Brew Product" select for the valid names on your model.
         Mutually exclusive with recipe.
       example: Espresso
       selector:

--- a/custom_components/jura/services.yaml
+++ b/custom_components/jura/services.yaml
@@ -69,7 +69,9 @@ brew:
         text:
     strength:
       name: Coffee strength
-      description: Optional strength level (model-specific, e.g. 1-10). Defaults to the machine's value.
+      description: >-
+        Optional strength level (model-specific, e.g. 1-10). Omit for the
+        product's factory default. Clamped to the product's valid range.
       selector:
         number:
           min: 1
@@ -77,7 +79,9 @@ brew:
           mode: box
     water_ml:
       name: Water
-      description: Optional water amount in millilitres. Defaults to the machine's value.
+      description: >-
+        Optional water amount in millilitres. Omit for the product's factory
+        default. Clamped to the product's valid range.
       selector:
         number:
           min: 0
@@ -86,7 +90,9 @@ brew:
           mode: box
     temperature:
       name: Temperature
-      description: Optional temperature level (model-specific, e.g. 1 = Normal, 2 = High). Defaults to the machine's value.
+      description: >-
+        Optional temperature level (model-specific, e.g. 1 = Normal, 2 = High).
+        Omit for the product's factory default. Clamped to the product's valid set.
       selector:
         number:
           min: 1

--- a/custom_components/jura/services.yaml
+++ b/custom_components/jura/services.yaml
@@ -129,20 +129,6 @@ descale:
         entity:
           integration: jura
 
-decalc:
-  name: Descale (legacy alias)
-  description: Deprecated alias of the Descale service. Start the descaling cycle (30+ min, requires descaler in tank).
-  fields:
-    config_entry_id:
-      name: Config Entry ID
-      selector:
-        text:
-    entity_id:
-      name: Entity
-      selector:
-        entity:
-          integration: jura
-
 filter_change:
   name: Filter Change
   description: Run the water-filter change procedure.

--- a/custom_components/jura/services.yaml
+++ b/custom_components/jura/services.yaml
@@ -44,7 +44,10 @@ unlock_screen:
 
 brew:
   name: Brew
-  description: Start brewing a product. Recipe codes are firmware-specific (e.g. 01 = espresso on many models).
+  description: >-
+    Brew a drink. Pick a product by name (optionally overriding
+    strength/water/temperature), or pass a raw recipe payload. This
+    PHYSICALLY brews a drink on the machine.
   fields:
     config_entry_id:
       name: Config Entry ID
@@ -55,10 +58,46 @@ brew:
       selector:
         entity:
           integration: jura
+    product:
+      name: Product
+      description: >-
+        Product name from the machine's product table (e.g. "Espresso").
+        See the "Brew <product>" buttons for the valid names on your model.
+        Mutually exclusive with recipe.
+      example: Espresso
+      selector:
+        text:
+    strength:
+      name: Coffee strength
+      description: Optional strength level (model-specific, e.g. 1-10). Defaults to the machine's value.
+      selector:
+        number:
+          min: 1
+          max: 16
+          mode: box
+    water_ml:
+      name: Water
+      description: Optional water amount in millilitres. Defaults to the machine's value.
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: mL
+          mode: box
+    temperature:
+      name: Temperature
+      description: Optional temperature level (model-specific, e.g. 1 = Normal, 2 = High). Defaults to the machine's value.
+      selector:
+        number:
+          min: 1
+          max: 3
+          mode: box
     recipe:
-      name: Recipe
-      description: Product code, e.g. "01" for espresso. Consult your machine's documentation.
-      required: true
+      name: Recipe (advanced)
+      description: >-
+        Raw 16-byte hex payload without the @TP: prefix (legacy/advanced).
+        Mutually exclusive with product.
+      example: "02000809000002000100000000000000"
       selector:
         text:
 
@@ -76,9 +115,23 @@ clean:
         entity:
           integration: jura
 
-decalc:
-  name: Start Descaling Cycle
+descale:
+  name: Descale
   description: Start the descaling cycle (30+ min, requires descaler in tank).
+  fields:
+    config_entry_id:
+      name: Config Entry ID
+      selector:
+        text:
+    entity_id:
+      name: Entity
+      selector:
+        entity:
+          integration: jura
+
+decalc:
+  name: Descale (legacy alias)
+  description: Deprecated alias of the Descale service. Start the descaling cycle (30+ min, requires descaler in tank).
   fields:
     config_entry_id:
       name: Config Entry ID

--- a/info.md
+++ b/info.md
@@ -13,7 +13,7 @@ account.
   milk warning, …)
 - Per-recipe brew counters (espresso, coffee, cappuccino, …) plus a
   lifetime total
-- Maintenance counters and percent-to-next indicators (cleaning, decalc,
+- Maintenance counters and percent-to-next indicators (cleaning, descale,
   filter, cappu rinse)
 - Machine settings as dropdowns / sliders (language, units, auto-off,
   water hardness, milk rinsing, …) with profile-driven validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-jura-connect"
-version = "0.9.0"
+version = "0.10.0"
 requires-python = ">=3.13"
 dependencies = [
     "jura_connect>=0.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-jura-connect"
-version = "0.7.4"
+version = "0.8.0"
 requires-python = ">=3.13"
 dependencies = [
     "jura_connect>=0.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-jura-connect"
-version = "0.8.0"
+version = "0.9.0"
 requires-python = ">=3.13"
 dependencies = [
     "jura_connect>=0.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-jura-connect"
-version = "0.10.0"
+version = "0.10.1"
 requires-python = ">=3.13"
 dependencies = [
     "jura_connect>=0.9.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,52 @@ _make_module(
 _make_module("homeassistant.helpers.entity_platform", AddEntitiesCallback=list)
 
 
+# --- homeassistant.helpers.storage ---
+class Store:
+    """Minimal persistent Store stub.
+
+    Mimics enough of ``homeassistant.helpers.storage.Store`` for the brew-prefs
+    persistence path: a process-wide, key-addressed backing dict stands in for
+    on-disk JSON. ``async_delay_save`` resolves and stores the data immediately
+    (the real one debounces) so load/save round-trips are deterministic in
+    tests. Values are deep-copied in/out to mimic JSON (de)serialisation, so the
+    in-memory caller dict and the "stored" copy never alias.
+    """
+
+    _backing: dict[str, object] = {}
+
+    def __init__(self, hass, version, key, **kwargs):
+        self.hass = hass
+        self.version = version
+        self.key = key
+
+    async def async_load(self):
+        import copy
+
+        return copy.deepcopy(Store._backing.get(self.key))
+
+    def async_delay_save(self, data_func, delay=0):
+        import copy
+
+        Store._backing[self.key] = copy.deepcopy(data_func())
+
+    async def async_save(self, data):
+        import copy
+
+        Store._backing[self.key] = copy.deepcopy(data)
+
+
+_make_module("homeassistant.helpers.storage", Store=Store)
+
+
+@pytest.fixture(autouse=True)
+def _clear_store_backing():
+    """Isolate persistence tests: wipe the Store's backing between tests."""
+    Store._backing.clear()
+    yield
+    Store._backing.clear()
+
+
 # --- homeassistant.helpers.update_coordinator ---
 class UpdateFailed(Exception):
     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ class Platform:
     BINARY_SENSOR = "binary_sensor"
     SELECT = "select"
     NUMBER = "number"
+    BUTTON = "button"
 
 
 class EntityCategory(str, Enum):
@@ -267,6 +268,11 @@ class CoordinatorEntity:
     def __init__(self, coordinator):
         self.coordinator = coordinator
 
+    def async_write_ha_state(self):
+        # Real HA pushes the new state to the registry/state machine; the
+        # test stub only needs the method to exist so entities can call it.
+        pass
+
 
 _make_module(
     "homeassistant.helpers.update_coordinator",
@@ -368,6 +374,24 @@ class NumberEntity:
 
 
 _make_module("homeassistant.components.number", NumberEntity=NumberEntity)
+
+
+# --- homeassistant.components.button ---
+class ButtonEntity:
+    @property
+    def unique_id(self):
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def name(self):
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def entity_category(self):
+        return getattr(self, "_attr_entity_category", None)
+
+
+_make_module("homeassistant.components.button", ButtonEntity=ButtonEntity)
 
 
 # --- homeassistant.components.binary_sensor ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,11 @@ class DataUpdateCoordinator:
         self.data = data
         self.last_update_success = True
 
+    def async_update_listeners(self):
+        # Real HA pushes a state update to every registered CoordinatorEntity;
+        # entities in tests read coordinator state live, so this is a no-op.
+        pass
+
     async def _async_update_data(self):
         raise NotImplementedError
 

--- a/tests/test_brew_payload.py
+++ b/tests/test_brew_payload.py
@@ -1,0 +1,77 @@
+"""Brew-payload encoding tests.
+
+These pin the ``@TP:`` start-command encoding against two vectors that
+were validated live on a JURA E6 (a real coffee was brewed from each).
+The logic under test is framework-free (pure stdlib), so this module
+imports nothing from Home Assistant and makes no network calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.jura.brew import ProductArg, ProductDef, build_start_command
+
+
+def _product(code: str, args: list[ProductArg]) -> ProductDef:
+    return ProductDef(code=code, name="x", picture=None, pos_csv=None, args=tuple(args))
+
+
+def test_vector_1_coffee_with_overrides() -> None:
+    """Coffee(0x03), strength 2, 130 ml, temp Normal(0x01).
+
+    130 // 5 == 26 == 0x1A.
+    """
+    product = _product(
+        "03",
+        [
+            ProductArg(kind="COFFEE_STRENGTH", argument="F3", index=2, default=5),
+            ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=120, min=25, max=240, step=5),
+            ProductArg(kind="TEMPERATURE", argument="F7", index=6, default=2),
+        ],
+    )
+    assert build_start_command(product, strength=2, water_ml=130, temp=1) == "@TP:0300021A000001000100000000000000"
+
+
+def test_vector_2_espresso_defaults() -> None:
+    """Default Espresso: code 0x02, strength 8, 45 ml (-> 9), temp 0x02."""
+    product = _product(
+        "02",
+        [
+            ProductArg(kind="COFFEE_STRENGTH", argument="F3", index=2, default=8),
+            ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=45, min=25, max=240, step=5),
+            ProductArg(kind="TEMPERATURE", argument="F7", index=6, default=2),
+        ],
+    )
+    assert build_start_command(product) == "@TP:02000809000002000100000000000000"
+
+
+def test_payload_is_uppercase_and_16_bytes() -> None:
+    product = _product(
+        "03",
+        [ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=255, step=1)],
+    )
+    out = build_start_command(product, water_ml=255)
+    assert out.startswith("@TP:")
+    hex_part = out.removeprefix("@TP:")
+    assert len(hex_part) == 32
+    assert hex_part == hex_part.upper()
+
+
+def test_brew_xml_path_end_to_end() -> None:
+    """The XML sourcing path: resolve jura_connect's bundled data and
+    encode a real product. Validates importlib.resources wiring +
+    encoding shape without asserting machine-specific defaults.
+    """
+    pytest.importorskip("jura_connect")
+    from custom_components.jura.brew import jura_connect_xml_dir, load_definition
+
+    base_dir = jura_connect_xml_dir()
+    assert base_dir is not None
+    definition = load_definition("EF1091", base_dir=base_dir)
+    assert definition is not None
+    assert definition.products
+    for product in definition.products:
+        payload = build_start_command(product)
+        assert payload.startswith("@TP:")
+        assert len(payload.removeprefix("@TP:")) == 32

--- a/tests/test_brew_payload.py
+++ b/tests/test_brew_payload.py
@@ -162,6 +162,28 @@ def test_factory_default_emits_xml_default_payload() -> None:
     )
 
 
+def test_milk_foam_amount_f6_default_encoded() -> None:
+    """MILK_FOAM_AMOUNT (F6, index 5) brews at its default: 22 // 1 -> 0x16.
+
+    Derived from the EF1030 XML (not yet live-brewed): a milk drink previously
+    left its milk-foam byte at 0x00 because only F3/F4/F7 were encoded.
+    """
+    product = _product(
+        "08",
+        [ProductArg(kind="MILK_FOAM_AMOUNT", argument="F6", index=5, default=22, min=1, max=45, step=1)],
+    )
+    assert build_start_command(product) == "@TP:08000000001600000100000000000000"
+
+
+def test_bypass_f10_default_encoded() -> None:
+    """BYPASS (F10, index 9) brews at its default: 40 // 5 -> 0x08."""
+    product = _product(
+        "28",
+        [ProductArg(kind="BYPASS", argument="F10", index=9, default=40, min=0, max=240, step=5)],
+    )
+    assert _byte(build_start_command(product), 9) == "08"
+
+
 def test_brew_xml_path_end_to_end() -> None:
     """The XML sourcing path: resolve jura_connect's bundled data and
     encode a real product. Validates importlib.resources wiring +

--- a/tests/test_brew_payload.py
+++ b/tests/test_brew_payload.py
@@ -58,6 +58,110 @@ def test_payload_is_uppercase_and_16_bytes() -> None:
     assert hex_part == hex_part.upper()
 
 
+# ---------------------------------------------------------------------------
+# Clamping. JURA WiFi takes per-byte literals (no sentinels): an out-of-range
+# water byte floods the machine (0xFF -> 255*step ml) rather than meaning
+# "max". So every value MUST be clamped to the product's XML range before it
+# goes on the wire.
+# ---------------------------------------------------------------------------
+
+
+def _byte(payload: str, index: int) -> str:
+    hex_part = payload.removeprefix("@TP:")
+    return hex_part[index * 2 : index * 2 + 2]
+
+
+def test_water_clamps_to_max_not_overflow() -> None:
+    """A huge water request clamps to Max, it must NOT wrap mod 256.
+
+    Max 240 ml / step 5 -> 48 == 0x30. The old ``& 0xFF`` masking would
+    have yielded 99999 // 5 == 19999 -> 0x1F (a silent, wrong value).
+    """
+    product = _product(
+        "03",
+        [ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=120, min=25, max=240, step=5)],
+    )
+    out = build_start_command(product, water_ml=99999)
+    assert _byte(out, 3) == "30"
+    assert _byte(out, 3) != "FF"
+    assert _byte(out, 3) != "1F"
+
+
+def test_water_clamps_to_min() -> None:
+    """Below Min clamps up to Min (25 ml / step 5 -> 5 == 0x05)."""
+    product = _product(
+        "03",
+        [ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=120, min=25, max=240, step=5)],
+    )
+    out = build_start_command(product, water_ml=0)
+    assert _byte(out, 3) == "05"
+
+
+def test_strength_clamps_to_item_set() -> None:
+    """Strength above the highest ITEM clamps to it (items 1..10 -> 0x0A)."""
+    product = _product(
+        "03",
+        [
+            ProductArg(
+                kind="COFFEE_STRENGTH",
+                argument="F3",
+                index=2,
+                default=5,
+                items=tuple((str(n), n) for n in range(1, 11)),
+            )
+        ],
+    )
+    out = build_start_command(product, strength=99)
+    assert _byte(out, 2) == "0A"
+
+
+def test_temp_clamps_to_item_set() -> None:
+    """Temperature outside the ITEM set clamps into it (items 0..2 -> 0x02)."""
+    product = _product(
+        "03",
+        [
+            ProductArg(
+                kind="TEMPERATURE",
+                argument="F7",
+                index=6,
+                default=1,
+                items=(("Low", 0), ("Normal", 1), ("High", 2)),
+            )
+        ],
+    )
+    out = build_start_command(product, temp=7)
+    assert _byte(out, 6) == "02"
+
+
+def test_no_byte_exceeds_0xff_without_max() -> None:
+    """With no Max defined, the encoded byte is still capped at 0xFF."""
+    product = _product(
+        "03",
+        [ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=10, step=1)],
+    )
+    out = build_start_command(product, water_ml=99999)
+    assert _byte(out, 3) == "FF"
+
+
+def test_factory_default_emits_xml_default_payload() -> None:
+    """``None`` params == Factory Default == the product's XML default bytes.
+
+    Strength None -> default 8 (0x08), water None -> default 45//5 (0x09),
+    temp None -> default 2 (0x02): the validated Espresso default vector.
+    """
+    product = _product(
+        "02",
+        [
+            ProductArg(kind="COFFEE_STRENGTH", argument="F3", index=2, default=8),
+            ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=45, min=25, max=240, step=5),
+            ProductArg(kind="TEMPERATURE", argument="F7", index=6, default=2),
+        ],
+    )
+    assert build_start_command(product, strength=None, water_ml=None, temp=None) == (
+        "@TP:02000809000002000100000000000000"
+    )
+
+
 def test_brew_xml_path_end_to_end() -> None:
     """The XML sourcing path: resolve jura_connect's bundled data and
     encode a real product. Validates importlib.resources wiring +

--- a/tests/test_brew_platform.py
+++ b/tests/test_brew_platform.py
@@ -1,63 +1,130 @@
-"""Tests for the brew button + per-product brew-parameter entities.
+"""Tests for the compact brew "control panel".
 
-The parameter entities (strength/temperature selects, water number) stage
-the "next brew" values on the coordinator; the brew button reads them and
-encodes the ``@TP:`` start command. None of this talks to a machine — the
-button's ``run_command`` is mocked, so no live brew happens in tests.
+The redesigned brew UX is five entities shared across the whole machine
+(not per product): a product select, strength/water/temperature selects
+(each carrying a "Machine Default" sentinel), and a single brew button.
+Selections are staged on ``coordinator.brew_selection``; the button reads
+them and encodes the ``@TP:`` start command. Nothing talks to a machine —
+``run_command`` is mocked, so no live brew happens in tests.
+
+These exercise the real EF1030 (E6) bundled definition so the option
+lists, defaults and the two live-validated payload vectors are pinned
+against actual machine data.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
-from custom_components.jura.brew import ProductArg, ProductDef
-from custom_components.jura.button import JuraBrewButton
-from custom_components.jura.const import DOMAIN
-from custom_components.jura.number import BrewWaterNumber
-from custom_components.jura.select import BrewParamSelect
+jura_connect = pytest.importorskip("jura_connect")
 
-# Default payload for the product below (validated shape):
-#   code 30, strength 8 (idx2=08), water 90//5=18=0x12 (idx3=12),
-#   temp 2 (idx6=02), idx8=01 -> "30000812000002000100000000000000"
-_DEFAULT_RECIPE = "30000812000002000100000000000000"
-# After staging strength 2, water 130 (->0x1A), temp Normal(1):
-_STAGED_RECIPE = "3000021A000001000100000000000000"
+from custom_components.jura.button import JuraBrewButton  # noqa: E402
+from custom_components.jura.const import (  # noqa: E402
+    CONF_AUTH_HASH,
+    CONF_CONN_ID,
+    CONF_HOST,
+    CONF_MACHINE_TYPE,
+    CONF_PIN,
+    CONF_PORT,
+    DOMAIN,
+)
+from custom_components.jura.coordinator import JuraCoordinator  # noqa: E402
+from custom_components.jura.select import (  # noqa: E402
+    BrewProductSelect,
+    BrewStrengthSelect,
+    BrewTempSelect,
+    BrewWaterSelect,
+)
+from homeassistant.config_entries import ConfigEntry  # noqa: E402
+
+MACHINE_DEFAULT = "Machine Default"
+
+# EF1030 (E6) product names, in definition order.
+_EF1030_PRODUCTS = [
+    "Espresso",
+    "Coffee",
+    "Cappuccino",
+    "Espresso Macchiato",
+    "Hotwater Portion(normal)",
+    "2 Espressi",
+    "2 Coffee",
+]
+
+# Live-validated payload vectors (a real coffee was brewed from each):
+#   default Espresso (code 02, strength 8, 45ml->9, temp 2)
+_ESPRESSO_DEFAULT = "02000809000002000100000000000000"
+#   Coffee (code 03), strength 2, 130ml (->0x1A), temp Normal(1)
+_COFFEE_OVERRIDE = "0300021A000001000100000000000000"
 
 
-def _product() -> ProductDef:
-    return ProductDef(
-        code="30",
-        name="Espresso Doppio",
-        picture=None,
-        pos_csv=17,
-        args=(
-            ProductArg(
-                kind="COFFEE_STRENGTH",
-                argument="F3",
-                index=2,
-                default=8,
-                items=tuple((str(i), i) for i in range(1, 11)),
-            ),
-            ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=90, min=30, max=160, step=5),
-            ProductArg(
-                kind="TEMPERATURE",
-                argument="F7",
-                index=6,
-                default=2,
-                items=(("Normal", 1), ("High", 2)),
-            ),
-        ),
+def _entry(machine_type: str = "EF1030") -> ConfigEntry:
+    return ConfigEntry(
+        entry_id="test_entry_id",
+        data={
+            CONF_HOST: "192.0.2.10",
+            CONF_PORT: 51515,
+            CONF_PIN: "",
+            CONF_CONN_ID: "homeassistant-test",
+            CONF_AUTH_HASH: "a" * 64,
+            CONF_MACHINE_TYPE: machine_type,
+        },
     )
 
 
-def _coordinator() -> MagicMock:
-    c = MagicMock()
-    c.brew_params = {}
-    c.run_command = AsyncMock(return_value={"name": "brew", "value": "ok"})
-    c.data = None
-    return c
+def _coordinator(entry: ConfigEntry | None = None) -> JuraCoordinator:
+    """A real coordinator (so brew_definition/brew_selection/selected_product
+    come from the live EF1030 data) with the machine-touching surfaces mocked."""
+    entry = entry or _entry()
+    backend = AsyncMock()
+    coordinator = JuraCoordinator(AsyncMock(), entry, backend=backend)
+    coordinator.run_command = AsyncMock(return_value={"name": "brew", "value": "ok"})
+    coordinator.data = None
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Coordinator brew_selection seeding
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_seeds_first_product_and_default_params():
+    coordinator = _coordinator()
+    assert coordinator.brew_selection == {
+        "product": "02",  # Espresso is the first EF1030 product
+        "strength": None,
+        "water_ml": None,
+        "temp": None,
+    }
+    assert coordinator.selected_product().name == "Espresso"
+
+
+# ---------------------------------------------------------------------------
+# Product select
+# ---------------------------------------------------------------------------
+
+
+def test_product_select_options_and_current(fake_config_entry):
+    coordinator = _coordinator()
+    entity = BrewProductSelect(coordinator, _entry())
+    assert entity.options == _EF1030_PRODUCTS
+    assert entity.current_option == "Espresso"
+    assert entity.entity_category == "config"
+    assert entity.unique_id.endswith("brew_product")
+
+
+async def test_product_select_sets_code_and_resets_params():
+    coordinator = _coordinator()
+    # Stage some non-default params first.
+    coordinator.brew_selection.update(strength=4, water_ml=120, temp=2)
+    entity = BrewProductSelect(coordinator, _entry())
+    await entity.async_select_option("Coffee")
+    assert coordinator.brew_selection["product"] == "03"
+    assert coordinator.brew_selection["strength"] is None
+    assert coordinator.brew_selection["water_ml"] is None
+    assert coordinator.brew_selection["temp"] is None
+    assert entity.current_option == "Coffee"
 
 
 # ---------------------------------------------------------------------------
@@ -65,24 +132,63 @@ def _coordinator() -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-def test_strength_select_options_and_seeded_default(fake_config_entry):
-    coordinator = _coordinator()
-    product = _product()
-    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("COFFEE_STRENGTH"))
-    assert entity.options == [str(i) for i in range(1, 11)]
-    assert entity.current_option == "8"  # default byte 8 -> item name "8"
-    assert coordinator.brew_params["30"]["strength"] == 8
+def test_strength_select_options_and_default():
+    coordinator = _coordinator()  # Espresso selected
+    entity = BrewStrengthSelect(coordinator, _entry())
+    assert entity.options == [MACHINE_DEFAULT, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.available is True
     assert entity.entity_category == "config"
-    assert entity.unique_id.endswith("brew_30_strength")
+    assert entity.unique_id.endswith("brew_strength")
 
 
-async def test_strength_select_set_stages_value(fake_config_entry):
+async def test_strength_select_set_and_machine_default():
     coordinator = _coordinator()
-    product = _product()
-    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("COFFEE_STRENGTH"))
+    entity = BrewStrengthSelect(coordinator, _entry())
     await entity.async_select_option("2")
-    assert coordinator.brew_params["30"]["strength"] == 2
+    assert coordinator.brew_selection["strength"] == 2
     assert entity.current_option == "2"
+    await entity.async_select_option(MACHINE_DEFAULT)
+    assert coordinator.brew_selection["strength"] is None
+    assert entity.current_option == MACHINE_DEFAULT
+
+
+async def test_strength_select_unavailable_without_strength_arg():
+    coordinator = _coordinator()
+    product = BrewProductSelect(coordinator, _entry())
+    strength = BrewStrengthSelect(coordinator, _entry())
+    # Hotwater has no COFFEE_STRENGTH argument.
+    await product.async_select_option("Hotwater Portion(normal)")
+    assert strength.available is False
+    assert strength.current_option is None
+    assert strength.options == [MACHINE_DEFAULT]
+
+
+# ---------------------------------------------------------------------------
+# Water select
+# ---------------------------------------------------------------------------
+
+
+def test_water_select_options_from_range():
+    coordinator = _coordinator()  # Espresso: 15..80 step 5
+    entity = BrewWaterSelect(coordinator, _entry())
+    assert entity.options == [MACHINE_DEFAULT, *[str(v) for v in range(15, 81, 5)]]
+    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.unique_id.endswith("brew_water_ml")
+
+
+async def test_water_select_set_and_machine_default():
+    coordinator = _coordinator()
+    product = BrewProductSelect(coordinator, _entry())
+    water = BrewWaterSelect(coordinator, _entry())
+    await product.async_select_option("Coffee")  # 25..240 step 5
+    assert "130" in water.options
+    await water.async_select_option("130")
+    assert coordinator.brew_selection["water_ml"] == 130
+    assert water.current_option == "130"
+    await water.async_select_option(MACHINE_DEFAULT)
+    assert coordinator.brew_selection["water_ml"] is None
+    assert water.current_option == MACHINE_DEFAULT
 
 
 # ---------------------------------------------------------------------------
@@ -90,47 +196,22 @@ async def test_strength_select_set_stages_value(fake_config_entry):
 # ---------------------------------------------------------------------------
 
 
-def test_temperature_select_options_and_default(fake_config_entry):
+def test_temp_select_options_and_mapping():
     coordinator = _coordinator()
-    product = _product()
-    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("TEMPERATURE"))
-    assert entity.options == ["Normal", "High"]
-    assert entity.current_option == "High"  # default byte 2
-    assert coordinator.brew_params["30"]["temp"] == 2
+    entity = BrewTempSelect(coordinator, _entry())
+    assert entity.options == [MACHINE_DEFAULT, "Low", "Normal", "High"]
+    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.unique_id.endswith("brew_temp")
 
 
-async def test_temperature_select_set_stages_value(fake_config_entry):
+async def test_temp_select_set_and_machine_default():
     coordinator = _coordinator()
-    product = _product()
-    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("TEMPERATURE"))
+    entity = BrewTempSelect(coordinator, _entry())
     await entity.async_select_option("Normal")
-    assert coordinator.brew_params["30"]["temp"] == 1
-
-
-# ---------------------------------------------------------------------------
-# Water number
-# ---------------------------------------------------------------------------
-
-
-def test_water_number_range_and_default(fake_config_entry):
-    coordinator = _coordinator()
-    product = _product()
-    entity = BrewWaterNumber(coordinator, fake_config_entry, product, product.arg("WATER_AMOUNT"))
-    assert entity.native_min_value == 30.0
-    assert entity.native_max_value == 160.0
-    assert entity.native_step == 5.0
-    assert entity.native_value == 90.0
-    assert entity.entity_category == "config"
-    assert coordinator.brew_params["30"]["water_ml"] == 90
-
-
-async def test_water_number_set_stages_value(fake_config_entry):
-    coordinator = _coordinator()
-    product = _product()
-    entity = BrewWaterNumber(coordinator, fake_config_entry, product, product.arg("WATER_AMOUNT"))
-    await entity.async_set_native_value(130)
-    assert coordinator.brew_params["30"]["water_ml"] == 130
-    assert entity.native_value == 130.0
+    assert coordinator.brew_selection["temp"] == 1
+    assert entity.current_option == "Normal"
+    await entity.async_select_option(MACHINE_DEFAULT)
+    assert coordinator.brew_selection["temp"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -138,81 +219,92 @@ async def test_water_number_set_stages_value(fake_config_entry):
 # ---------------------------------------------------------------------------
 
 
-def test_button_name_and_unique_id(fake_config_entry):
+def test_button_name_and_unique_id():
     coordinator = _coordinator()
-    product = _product()
-    button = JuraBrewButton(coordinator, fake_config_entry, product)
-    assert button.name == "Brew Espresso Doppio"
-    assert button.unique_id.endswith("brew_30")
+    button = JuraBrewButton(coordinator, _entry())
+    assert button.name == "Brew"
+    assert button.unique_id.endswith("homeassistant_test_brew")
 
 
-async def test_button_press_uses_xml_defaults_when_unstaged(fake_config_entry):
-    coordinator = _coordinator()
-    product = _product()
-    button = JuraBrewButton(coordinator, fake_config_entry, product)
+async def test_button_press_espresso_machine_default_vector():
+    """Espresso, all Machine Default -> the live-validated default vector."""
+    coordinator = _coordinator()  # Espresso selected, all params None
+    button = JuraBrewButton(coordinator, _entry())
     await button.async_press()
-    coordinator.run_command.assert_awaited_once_with("brew", [_DEFAULT_RECIPE], allow_destructive=True)
+    coordinator.run_command.assert_awaited_once_with("brew", [_ESPRESSO_DEFAULT], allow_destructive=True)
     # The recipe must NOT carry the @TP: prefix (the library re-adds it).
     sent = coordinator.run_command.await_args.args[1][0]
     assert not sent.startswith("@TP:")
 
 
-async def test_button_press_reads_staged_param_entities(fake_config_entry):
+async def test_button_press_coffee_override_vector_via_selection_path():
+    """Select Coffee + strength 2 + water 130 + temp Normal -> override vector.
+
+    Drives the full selection path through the shared coordinator: every
+    entity reads/writes the same ``brew_selection``.
+    """
     coordinator = _coordinator()
-    product = _product()
-    # Build the param entities so they seed + accept staged values, sharing
-    # the same coordinator the button reads from.
-    strength = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("COFFEE_STRENGTH"))
-    water = BrewWaterNumber(coordinator, fake_config_entry, product, product.arg("WATER_AMOUNT"))
-    temperature = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("TEMPERATURE"))
+    entry = _entry()
+    product = BrewProductSelect(coordinator, entry)
+    strength = BrewStrengthSelect(coordinator, entry)
+    water = BrewWaterSelect(coordinator, entry)
+    temp = BrewTempSelect(coordinator, entry)
+    button = JuraBrewButton(coordinator, entry)
+
+    await product.async_select_option("Coffee")
     await strength.async_select_option("2")
-    await water.async_set_native_value(130)
-    await temperature.async_select_option("Normal")
-
-    button = JuraBrewButton(coordinator, fake_config_entry, product)
+    await water.async_select_option("130")
+    await temp.async_select_option("Normal")
     await button.async_press()
-    coordinator.run_command.assert_awaited_once_with("brew", [_STAGED_RECIPE], allow_destructive=True)
+
+    coordinator.run_command.assert_awaited_once_with("brew", [_COFFEE_OVERRIDE], allow_destructive=True)
 
 
 # ---------------------------------------------------------------------------
-# Platform setup against the real EF1091 (S8) bundled definition
+# Platform setup: the five-entity control panel on a real EF1030
 # ---------------------------------------------------------------------------
 
 
-async def test_button_setup_creates_one_button_per_product(fake_config_entry):
-    pytest.importorskip("jura_connect")
-    from custom_components.jura.button import async_setup_entry
+async def _setup(platform_module):
+    from importlib import import_module
 
     coordinator = _coordinator()
-    hass = MagicMock()
-    hass.data = {DOMAIN: {fake_config_entry.entry_id: coordinator}}
+    hass = AsyncMock()
+    hass.data = {DOMAIN: {"test_entry_id": coordinator}}
     added: list = []
-    await async_setup_entry(hass, fake_config_entry, added.extend)
-    assert added
-    assert all(e.name.startswith("Brew ") for e in added)
+    module = import_module(platform_module)
+    await module.async_setup_entry(hass, _entry(), added.extend)
+    return added
 
 
-async def test_select_setup_includes_brew_param_selects(fake_config_entry):
-    pytest.importorskip("jura_connect")
-    from custom_components.jura.select import async_setup_entry
+async def test_select_setup_builds_control_panel_not_per_product():
+    added = await _setup("custom_components.jura.select")
+    names = [e.name for e in added]
+    assert "Brew Product" in names
+    assert "Brew Strength" in names
+    assert "Brew Water" in names
+    assert "Brew Temperature" in names
+    # Setting selects are still present...
+    assert any(n.startswith("Setting ") for n in names)
+    # ...but there is exactly one of each brew select (no per-product explosion).
+    assert sum(n.startswith("Brew ") for n in names) == 4
 
-    coordinator = _coordinator()
-    hass = MagicMock()
-    hass.data = {DOMAIN: {fake_config_entry.entry_id: coordinator}}
-    added: list = []
-    await async_setup_entry(hass, fake_config_entry, added.extend)
-    names = {e.name for e in added}
-    assert any("strength" in n for n in names)
-    assert any("temperature" in n for n in names)
+
+async def test_button_setup_creates_single_brew_button():
+    added = await _setup("custom_components.jura.button")
+    assert len(added) == 1
+    assert added[0].name == "Brew"
 
 
-async def test_number_setup_includes_brew_water_number(fake_config_entry):
-    pytest.importorskip("jura_connect")
-    from custom_components.jura.number import async_setup_entry
+async def test_number_setup_has_no_per_product_brew_water():
+    added = await _setup("custom_components.jura.number")
+    # Only machine-setting numbers remain (e.g. hardness); no brew water number.
+    assert all(e.name.startswith("Setting ") for e in added)
+    assert not any("Water" in e.name or "water" in e.name for e in added)
 
-    coordinator = _coordinator()
-    hass = MagicMock()
-    hass.data = {DOMAIN: {fake_config_entry.entry_id: coordinator}}
-    added: list = []
-    await async_setup_entry(hass, fake_config_entry, added.extend)
-    assert any("water" in e.name for e in added)
+
+async def test_ef1030_creates_exactly_five_brew_entities():
+    selects = await _setup("custom_components.jura.select")
+    buttons = await _setup("custom_components.jura.button")
+    brew_selects = [e for e in selects if e.name.startswith("Brew ")]
+    assert len(brew_selects) + len(buttons) == 5

--- a/tests/test_brew_platform.py
+++ b/tests/test_brew_platform.py
@@ -1,0 +1,218 @@
+"""Tests for the brew button + per-product brew-parameter entities.
+
+The parameter entities (strength/temperature selects, water number) stage
+the "next brew" values on the coordinator; the brew button reads them and
+encodes the ``@TP:`` start command. None of this talks to a machine — the
+button's ``run_command`` is mocked, so no live brew happens in tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.jura.brew import ProductArg, ProductDef
+from custom_components.jura.button import JuraBrewButton
+from custom_components.jura.const import DOMAIN
+from custom_components.jura.number import BrewWaterNumber
+from custom_components.jura.select import BrewParamSelect
+
+# Default payload for the product below (validated shape):
+#   code 30, strength 8 (idx2=08), water 90//5=18=0x12 (idx3=12),
+#   temp 2 (idx6=02), idx8=01 -> "30000812000002000100000000000000"
+_DEFAULT_RECIPE = "30000812000002000100000000000000"
+# After staging strength 2, water 130 (->0x1A), temp Normal(1):
+_STAGED_RECIPE = "3000021A000001000100000000000000"
+
+
+def _product() -> ProductDef:
+    return ProductDef(
+        code="30",
+        name="Espresso Doppio",
+        picture=None,
+        pos_csv=17,
+        args=(
+            ProductArg(
+                kind="COFFEE_STRENGTH",
+                argument="F3",
+                index=2,
+                default=8,
+                items=tuple((str(i), i) for i in range(1, 11)),
+            ),
+            ProductArg(kind="WATER_AMOUNT", argument="F4", index=3, default=90, min=30, max=160, step=5),
+            ProductArg(
+                kind="TEMPERATURE",
+                argument="F7",
+                index=6,
+                default=2,
+                items=(("Normal", 1), ("High", 2)),
+            ),
+        ),
+    )
+
+
+def _coordinator() -> MagicMock:
+    c = MagicMock()
+    c.brew_params = {}
+    c.run_command = AsyncMock(return_value={"name": "brew", "value": "ok"})
+    c.data = None
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Strength select
+# ---------------------------------------------------------------------------
+
+
+def test_strength_select_options_and_seeded_default(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("COFFEE_STRENGTH"))
+    assert entity.options == [str(i) for i in range(1, 11)]
+    assert entity.current_option == "8"  # default byte 8 -> item name "8"
+    assert coordinator.brew_params["30"]["strength"] == 8
+    assert entity.entity_category == "config"
+    assert entity.unique_id.endswith("brew_30_strength")
+
+
+async def test_strength_select_set_stages_value(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("COFFEE_STRENGTH"))
+    await entity.async_select_option("2")
+    assert coordinator.brew_params["30"]["strength"] == 2
+    assert entity.current_option == "2"
+
+
+# ---------------------------------------------------------------------------
+# Temperature select
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_select_options_and_default(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("TEMPERATURE"))
+    assert entity.options == ["Normal", "High"]
+    assert entity.current_option == "High"  # default byte 2
+    assert coordinator.brew_params["30"]["temp"] == 2
+
+
+async def test_temperature_select_set_stages_value(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    entity = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("TEMPERATURE"))
+    await entity.async_select_option("Normal")
+    assert coordinator.brew_params["30"]["temp"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Water number
+# ---------------------------------------------------------------------------
+
+
+def test_water_number_range_and_default(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    entity = BrewWaterNumber(coordinator, fake_config_entry, product, product.arg("WATER_AMOUNT"))
+    assert entity.native_min_value == 30.0
+    assert entity.native_max_value == 160.0
+    assert entity.native_step == 5.0
+    assert entity.native_value == 90.0
+    assert entity.entity_category == "config"
+    assert coordinator.brew_params["30"]["water_ml"] == 90
+
+
+async def test_water_number_set_stages_value(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    entity = BrewWaterNumber(coordinator, fake_config_entry, product, product.arg("WATER_AMOUNT"))
+    await entity.async_set_native_value(130)
+    assert coordinator.brew_params["30"]["water_ml"] == 130
+    assert entity.native_value == 130.0
+
+
+# ---------------------------------------------------------------------------
+# Brew button
+# ---------------------------------------------------------------------------
+
+
+def test_button_name_and_unique_id(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    button = JuraBrewButton(coordinator, fake_config_entry, product)
+    assert button.name == "Brew Espresso Doppio"
+    assert button.unique_id.endswith("brew_30")
+
+
+async def test_button_press_uses_xml_defaults_when_unstaged(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    button = JuraBrewButton(coordinator, fake_config_entry, product)
+    await button.async_press()
+    coordinator.run_command.assert_awaited_once_with("brew", [_DEFAULT_RECIPE], allow_destructive=True)
+    # The recipe must NOT carry the @TP: prefix (the library re-adds it).
+    sent = coordinator.run_command.await_args.args[1][0]
+    assert not sent.startswith("@TP:")
+
+
+async def test_button_press_reads_staged_param_entities(fake_config_entry):
+    coordinator = _coordinator()
+    product = _product()
+    # Build the param entities so they seed + accept staged values, sharing
+    # the same coordinator the button reads from.
+    strength = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("COFFEE_STRENGTH"))
+    water = BrewWaterNumber(coordinator, fake_config_entry, product, product.arg("WATER_AMOUNT"))
+    temperature = BrewParamSelect(coordinator, fake_config_entry, product, product.arg("TEMPERATURE"))
+    await strength.async_select_option("2")
+    await water.async_set_native_value(130)
+    await temperature.async_select_option("Normal")
+
+    button = JuraBrewButton(coordinator, fake_config_entry, product)
+    await button.async_press()
+    coordinator.run_command.assert_awaited_once_with("brew", [_STAGED_RECIPE], allow_destructive=True)
+
+
+# ---------------------------------------------------------------------------
+# Platform setup against the real EF1091 (S8) bundled definition
+# ---------------------------------------------------------------------------
+
+
+async def test_button_setup_creates_one_button_per_product(fake_config_entry):
+    pytest.importorskip("jura_connect")
+    from custom_components.jura.button import async_setup_entry
+
+    coordinator = _coordinator()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {fake_config_entry.entry_id: coordinator}}
+    added: list = []
+    await async_setup_entry(hass, fake_config_entry, added.extend)
+    assert added
+    assert all(e.name.startswith("Brew ") for e in added)
+
+
+async def test_select_setup_includes_brew_param_selects(fake_config_entry):
+    pytest.importorskip("jura_connect")
+    from custom_components.jura.select import async_setup_entry
+
+    coordinator = _coordinator()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {fake_config_entry.entry_id: coordinator}}
+    added: list = []
+    await async_setup_entry(hass, fake_config_entry, added.extend)
+    names = {e.name for e in added}
+    assert any("strength" in n for n in names)
+    assert any("temperature" in n for n in names)
+
+
+async def test_number_setup_includes_brew_water_number(fake_config_entry):
+    pytest.importorskip("jura_connect")
+    from custom_components.jura.number import async_setup_entry
+
+    coordinator = _coordinator()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {fake_config_entry.entry_id: coordinator}}
+    added: list = []
+    await async_setup_entry(hass, fake_config_entry, added.extend)
+    assert any("water" in e.name for e in added)

--- a/tests/test_brew_platform.py
+++ b/tests/test_brew_platform.py
@@ -42,15 +42,21 @@ from homeassistant.config_entries import ConfigEntry  # noqa: E402
 
 FACTORY_DEFAULT = "Factory Default"
 
-# EF1030 (E6) product names, in definition order.
+# EF1030 (E6) product names, in definition order. A product is brewable unless
+# it is explicitly Active="false"; the three drinks with no Active attribute
+# (Milk Foam, Cafe Barista, Barista Lungo) are included, only Powderproduct
+# (Active="false") is dropped.
 _EF1030_PRODUCTS = [
     "Espresso",
     "Coffee",
     "Cappuccino",
     "Espresso Macchiato",
+    "Milk Foam",
     "Hotwater Portion(normal)",
     "2 Espressi",
     "2 Coffee",
+    "Cafe Barista",
+    "Barista Lungo",
 ]
 
 # Live-validated payload vectors (a real coffee was brewed from each):

--- a/tests/test_brew_platform.py
+++ b/tests/test_brew_platform.py
@@ -2,9 +2,10 @@
 
 The redesigned brew UX is five entities shared across the whole machine
 (not per product): a product select, strength/water/temperature selects
-(each carrying a "Machine Default" sentinel), and a single brew button.
+(each carrying a "Factory Default" sentinel), and a single brew button.
 Selections are staged on ``coordinator.brew_selection``; the button reads
-them and encodes the ``@TP:`` start command. Nothing talks to a machine —
+them and encodes the ``@TP:`` start command. Per-product choices persist
+across restarts via ``coordinator.brew_prefs``. Nothing talks to a machine —
 ``run_command`` is mocked, so no live brew happens in tests.
 
 These exercise the real EF1030 (E6) bundled definition so the option
@@ -39,7 +40,7 @@ from custom_components.jura.select import (  # noqa: E402
 )
 from homeassistant.config_entries import ConfigEntry  # noqa: E402
 
-MACHINE_DEFAULT = "Machine Default"
+FACTORY_DEFAULT = "Factory Default"
 
 # EF1030 (E6) product names, in definition order.
 _EF1030_PRODUCTS = [
@@ -114,9 +115,10 @@ def test_product_select_options_and_current(fake_config_entry):
     assert entity.unique_id.endswith("brew_product")
 
 
-async def test_product_select_sets_code_and_resets_params():
+async def test_product_select_sets_code_and_loads_factory_default_params():
+    """With nothing saved for Coffee, switching to it loads all Factory Default."""
     coordinator = _coordinator()
-    # Stage some non-default params first.
+    # Stage some non-default params first (for the previously selected product).
     coordinator.brew_selection.update(strength=4, water_ml=120, temp=2)
     entity = BrewProductSelect(coordinator, _entry())
     await entity.async_select_option("Coffee")
@@ -127,6 +129,72 @@ async def test_product_select_sets_code_and_resets_params():
     assert entity.current_option == "Coffee"
 
 
+async def test_product_select_loads_saved_prefs_into_param_selects():
+    """A product with saved prefs hydrates the param selects when chosen."""
+    coordinator = _coordinator()
+    coordinator.brew_prefs["03"] = {"strength": 2, "water_ml": 130, "temp": 1}
+    entry = _entry()
+    product = BrewProductSelect(coordinator, entry)
+    strength = BrewStrengthSelect(coordinator, entry)
+    water = BrewWaterSelect(coordinator, entry)
+    temp = BrewTempSelect(coordinator, entry)
+
+    await product.async_select_option("Coffee")
+
+    assert coordinator.brew_selection == {
+        "product": "03",
+        "strength": 2,
+        "water_ml": 130,
+        "temp": 1,
+    }
+    assert strength.current_option == "2"
+    assert water.current_option == "130"
+    assert temp.current_option == "Normal"
+
+
+async def test_param_select_remembers_and_persists_across_restart():
+    """Net effect: set Coffee water once, it survives a coordinator restart.
+
+    Drives the real select entities (which call set_brew_param +
+    save_brew_prefs), then rebuilds the coordinator and reloads from the
+    (stubbed) Store to prove the value round-trips to "disk".
+    """
+    entry = _entry()
+    coordinator = _coordinator(entry)
+    await coordinator.async_load_brew_prefs()
+    product = BrewProductSelect(coordinator, entry)
+    water = BrewWaterSelect(coordinator, entry)
+
+    await product.async_select_option("Coffee")
+    await water.async_select_option("130")
+    assert coordinator.brew_prefs["03"]["water_ml"] == 130
+
+    # Restart: a fresh coordinator + reload reproduces the saved pref.
+    restarted = _coordinator(entry)
+    await restarted.async_load_brew_prefs()
+    assert restarted.brew_prefs["03"]["water_ml"] == 130
+    restarted.select_brew_product("03")
+    assert restarted.brew_selection["water_ml"] == 130
+
+
+async def test_param_select_factory_default_persists_none():
+    """Selecting Factory Default records None (and persists it)."""
+    entry = _entry()
+    coordinator = _coordinator(entry)
+    await coordinator.async_load_brew_prefs()
+    product = BrewProductSelect(coordinator, entry)
+    water = BrewWaterSelect(coordinator, entry)
+
+    await product.async_select_option("Coffee")
+    await water.async_select_option("130")
+    await water.async_select_option(FACTORY_DEFAULT)
+
+    assert coordinator.brew_prefs["03"]["water_ml"] is None
+    restarted = _coordinator(entry)
+    await restarted.async_load_brew_prefs()
+    assert restarted.brew_prefs.get("03", {}).get("water_ml") is None
+
+
 # ---------------------------------------------------------------------------
 # Strength select
 # ---------------------------------------------------------------------------
@@ -135,8 +203,8 @@ async def test_product_select_sets_code_and_resets_params():
 def test_strength_select_options_and_default():
     coordinator = _coordinator()  # Espresso selected
     entity = BrewStrengthSelect(coordinator, _entry())
-    assert entity.options == [MACHINE_DEFAULT, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
-    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.options == [FACTORY_DEFAULT, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+    assert entity.current_option == FACTORY_DEFAULT
     assert entity.available is True
     assert entity.entity_category == "config"
     assert entity.unique_id.endswith("brew_strength")
@@ -148,9 +216,9 @@ async def test_strength_select_set_and_machine_default():
     await entity.async_select_option("2")
     assert coordinator.brew_selection["strength"] == 2
     assert entity.current_option == "2"
-    await entity.async_select_option(MACHINE_DEFAULT)
+    await entity.async_select_option(FACTORY_DEFAULT)
     assert coordinator.brew_selection["strength"] is None
-    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.current_option == FACTORY_DEFAULT
 
 
 async def test_strength_select_unavailable_without_strength_arg():
@@ -161,7 +229,7 @@ async def test_strength_select_unavailable_without_strength_arg():
     await product.async_select_option("Hotwater Portion(normal)")
     assert strength.available is False
     assert strength.current_option is None
-    assert strength.options == [MACHINE_DEFAULT]
+    assert strength.options == [FACTORY_DEFAULT]
 
 
 # ---------------------------------------------------------------------------
@@ -172,8 +240,8 @@ async def test_strength_select_unavailable_without_strength_arg():
 def test_water_select_options_from_range():
     coordinator = _coordinator()  # Espresso: 15..80 step 5
     entity = BrewWaterSelect(coordinator, _entry())
-    assert entity.options == [MACHINE_DEFAULT, *[str(v) for v in range(15, 81, 5)]]
-    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.options == [FACTORY_DEFAULT, *[str(v) for v in range(15, 81, 5)]]
+    assert entity.current_option == FACTORY_DEFAULT
     assert entity.unique_id.endswith("brew_water_ml")
 
 
@@ -186,9 +254,9 @@ async def test_water_select_set_and_machine_default():
     await water.async_select_option("130")
     assert coordinator.brew_selection["water_ml"] == 130
     assert water.current_option == "130"
-    await water.async_select_option(MACHINE_DEFAULT)
+    await water.async_select_option(FACTORY_DEFAULT)
     assert coordinator.brew_selection["water_ml"] is None
-    assert water.current_option == MACHINE_DEFAULT
+    assert water.current_option == FACTORY_DEFAULT
 
 
 # ---------------------------------------------------------------------------
@@ -199,8 +267,8 @@ async def test_water_select_set_and_machine_default():
 def test_temp_select_options_and_mapping():
     coordinator = _coordinator()
     entity = BrewTempSelect(coordinator, _entry())
-    assert entity.options == [MACHINE_DEFAULT, "Low", "Normal", "High"]
-    assert entity.current_option == MACHINE_DEFAULT
+    assert entity.options == [FACTORY_DEFAULT, "Low", "Normal", "High"]
+    assert entity.current_option == FACTORY_DEFAULT
     assert entity.unique_id.endswith("brew_temp")
 
 
@@ -210,7 +278,7 @@ async def test_temp_select_set_and_machine_default():
     await entity.async_select_option("Normal")
     assert coordinator.brew_selection["temp"] == 1
     assert entity.current_option == "Normal"
-    await entity.async_select_option(MACHINE_DEFAULT)
+    await entity.async_select_option(FACTORY_DEFAULT)
     assert coordinator.brew_selection["temp"] is None
 
 
@@ -226,8 +294,8 @@ def test_button_name_and_unique_id():
     assert button.unique_id.endswith("homeassistant_test_brew")
 
 
-async def test_button_press_espresso_machine_default_vector():
-    """Espresso, all Machine Default -> the live-validated default vector."""
+async def test_button_press_espresso_factory_default_vector():
+    """Espresso, all Factory Default -> the live-validated default vector."""
     coordinator = _coordinator()  # Espresso selected, all params None
     button = JuraBrewButton(coordinator, _entry())
     await button.async_press()

--- a/tests/test_brew_prefs.py
+++ b/tests/test_brew_prefs.py
@@ -1,0 +1,61 @@
+"""Pure (framework-free) per-product brew-preference helpers.
+
+A *brew preference* is the remembered strength / water / temperature for one
+product, keyed by its hex Code. ``None`` for a parameter means Factory Default
+(send the product's XML default; pass ``None`` to ``build_start_command``).
+These helpers only touch plain dicts, so no Home Assistant / Store is needed.
+"""
+
+from __future__ import annotations
+
+from custom_components.jura.brew import (
+    BREW_PARAMS,
+    product_prefs,
+    remember_param,
+    selection_for_product,
+)
+
+
+def test_brew_params_are_the_three_recipe_axes():
+    assert BREW_PARAMS == ("strength", "water_ml", "temp")
+
+
+def test_product_prefs_missing_product_is_all_factory_default():
+    assert product_prefs({}, "03") == {"strength": None, "water_ml": None, "temp": None}
+
+
+def test_product_prefs_fills_missing_params_with_none():
+    prefs = {"03": {"water_ml": 130}}
+    assert product_prefs(prefs, "03") == {"strength": None, "water_ml": 130, "temp": None}
+
+
+def test_remember_then_load_reproduces_value():
+    """The core persistence contract: store a pref, read it back unchanged."""
+    prefs: dict[str, dict] = {}
+    remember_param(prefs, "03", "water_ml", 130)
+    assert product_prefs(prefs, "03")["water_ml"] == 130
+
+
+def test_remember_none_persists_factory_default_explicitly():
+    prefs: dict[str, dict] = {"03": {"water_ml": 130}}
+    remember_param(prefs, "03", "water_ml", None)
+    assert prefs["03"]["water_ml"] is None
+    assert product_prefs(prefs, "03")["water_ml"] is None
+
+
+def test_remember_is_per_product_isolated():
+    prefs: dict[str, dict] = {}
+    remember_param(prefs, "03", "water_ml", 130)
+    remember_param(prefs, "02", "water_ml", 45)
+    assert product_prefs(prefs, "03")["water_ml"] == 130
+    assert product_prefs(prefs, "02")["water_ml"] == 45
+
+
+def test_selection_for_product_includes_product_code():
+    prefs = {"03": {"strength": 2, "water_ml": 130, "temp": 1}}
+    assert selection_for_product(prefs, "03") == {
+        "product": "03",
+        "strength": 2,
+        "water_ml": 130,
+        "temp": 1,
+    }

--- a/tests/test_brew_service.py
+++ b/tests/test_brew_service.py
@@ -107,6 +107,32 @@ async def test_brew_by_product_with_overrides():
     coordinator.run_command.assert_awaited_once_with("brew", [_OVERRIDE_RECIPE], allow_destructive=True)
 
 
+async def test_brew_by_product_clamps_out_of_range_water():
+    """An absurd water_ml clamps to the product's Max, never wrapping mod 256.
+
+    Espresso Doppio water Max 160 / step 5 -> 32 == 0x20. The pre-clamp code
+    masked with ``& 0xFF`` and would have sent 99999 // 5 == 19999 -> 0x1F.
+    """
+    pytest.importorskip("jura_connect")
+    from custom_components.jura.brew import jura_connect_xml_dir, load_definition
+
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id", "product": "Espresso Doppio", "water_ml": 99999}
+    await _brew_handler(hass)(call)
+
+    sent = coordinator.run_command.await_args.args[1][0]
+    definition = load_definition("EF1091", base_dir=jura_connect_xml_dir())
+    product = next(p for p in definition.products if p.name.casefold() == "espresso doppio")
+    water = product.arg("WATER_AMOUNT")
+    expected = f"{water.max // (water.step or 1):02X}"
+    water_byte = sent[6:8]  # byte index 3 -> hex chars [6:8]
+    assert water_byte == expected
+    assert water_byte not in ("FF", "1F")
+
+
 async def test_brew_unknown_product_raises():
     pytest.importorskip("jura_connect")
     coordinator = _mock_coordinator()

--- a/tests/test_brew_service.py
+++ b/tests/test_brew_service.py
@@ -1,0 +1,164 @@
+"""Tests for the product-aware brew service and the decalc->descale rename.
+
+The ``jura.brew`` service gains a friendly ``product`` path (build the
+``@TP:`` payload from the machine's product table) while keeping the
+legacy raw ``recipe`` path intact. ``jura.descale`` is the renamed UI
+service; ``jura.decalc`` stays as a backwards-compat alias. Both map to
+the library's ``decalc`` command. No machine I/O — run_command is mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import voluptuous as vol
+
+from custom_components.jura import _register_services
+from custom_components.jura.const import CONF_CONN_ID, CONF_HOST, CONF_MACHINE_TYPE, DOMAIN
+
+_DEFAULT_RECIPE = "30000812000002000100000000000000"
+_OVERRIDE_RECIPE = "3000021A000001000100000000000000"
+
+
+def _hass_with_coordinator(coordinator) -> MagicMock:
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"test_entry_id": coordinator}}
+    services: dict[tuple[str, str], dict] = {}
+
+    def has_service(domain: str, name: str) -> bool:
+        return (domain, name) in services
+
+    def async_register(domain, name, handler, schema=None, supports_response=None):
+        services[(domain, name)] = {"handler": handler, "schema": schema, "supports_response": supports_response}
+
+    hass.services.has_service = has_service
+    hass.services.async_register = async_register
+    hass.services._registered = services
+    return hass
+
+
+def _mock_coordinator(machine_type: str = "EF1091") -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.run_command = AsyncMock(return_value={"name": "brew", "value": "ok"})
+    config_entry = MagicMock()
+    config_entry.data = {CONF_MACHINE_TYPE: machine_type, CONF_HOST: "192.0.2.10", CONF_CONN_ID: "x"}
+    coordinator.config_entry = config_entry
+    return coordinator
+
+
+def _brew_handler(hass):
+    return hass.services._registered[(DOMAIN, "brew")]["handler"]
+
+
+# ---------------------------------------------------------------------------
+# decalc -> descale rename
+# ---------------------------------------------------------------------------
+
+
+def test_descale_and_decalc_both_registered():
+    hass = _hass_with_coordinator(_mock_coordinator())
+    _register_services(hass)
+    assert (DOMAIN, "descale") in hass.services._registered
+    assert (DOMAIN, "decalc") in hass.services._registered
+
+
+async def test_descale_dispatches_library_decalc_command():
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    handler = hass.services._registered[(DOMAIN, "descale")]["handler"]
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id"}
+    await handler(call)
+    coordinator.run_command.assert_awaited_once_with("decalc", [], allow_destructive=True)
+
+
+async def test_decalc_alias_still_dispatches_decalc_command():
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    handler = hass.services._registered[(DOMAIN, "decalc")]["handler"]
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id"}
+    await handler(call)
+    coordinator.run_command.assert_awaited_once_with("decalc", [], allow_destructive=True)
+
+
+# ---------------------------------------------------------------------------
+# brew by product name (friendly path)
+# ---------------------------------------------------------------------------
+
+
+async def test_brew_by_product_uses_xml_defaults():
+    pytest.importorskip("jura_connect")
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id", "product": "Espresso Doppio"}
+    await _brew_handler(hass)(call)
+    coordinator.run_command.assert_awaited_once_with("brew", [_DEFAULT_RECIPE], allow_destructive=True)
+
+
+async def test_brew_by_product_with_overrides():
+    pytest.importorskip("jura_connect")
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {
+        "config_entry_id": "test_entry_id",
+        "product": "espresso doppio",  # case-insensitive
+        "strength": 2,
+        "water_ml": 130,
+        "temperature": 1,
+    }
+    await _brew_handler(hass)(call)
+    coordinator.run_command.assert_awaited_once_with("brew", [_OVERRIDE_RECIPE], allow_destructive=True)
+
+
+async def test_brew_unknown_product_raises():
+    pytest.importorskip("jura_connect")
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id", "product": "Nonexistent Drink"}
+    with pytest.raises(ValueError):
+        await _brew_handler(hass)(call)
+
+
+# ---------------------------------------------------------------------------
+# brew legacy recipe path + mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+async def test_brew_legacy_recipe_path_preserved():
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id", "recipe": "01"}
+    await _brew_handler(hass)(call)
+    coordinator.run_command.assert_awaited_once_with("brew", ["01"], allow_destructive=True)
+
+
+async def test_brew_rejects_product_and_recipe_together():
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id", "product": "Espresso Doppio", "recipe": "01"}
+    with pytest.raises(vol.Invalid):
+        await _brew_handler(hass)(call)
+
+
+async def test_brew_rejects_neither_product_nor_recipe():
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {"config_entry_id": "test_entry_id"}
+    with pytest.raises(vol.Invalid):
+        await _brew_handler(hass)(call)

--- a/tests/test_brew_service.py
+++ b/tests/test_brew_service.py
@@ -56,11 +56,11 @@ def _brew_handler(hass):
 # ---------------------------------------------------------------------------
 
 
-def test_descale_and_decalc_both_registered():
+def test_descale_registered_and_decalc_removed():
     hass = _hass_with_coordinator(_mock_coordinator())
     _register_services(hass)
     assert (DOMAIN, "descale") in hass.services._registered
-    assert (DOMAIN, "decalc") in hass.services._registered
+    assert (DOMAIN, "decalc") not in hass.services._registered
 
 
 async def test_descale_dispatches_library_decalc_command():
@@ -68,17 +68,6 @@ async def test_descale_dispatches_library_decalc_command():
     hass = _hass_with_coordinator(coordinator)
     _register_services(hass)
     handler = hass.services._registered[(DOMAIN, "descale")]["handler"]
-    call = MagicMock()
-    call.data = {"config_entry_id": "test_entry_id"}
-    await handler(call)
-    coordinator.run_command.assert_awaited_once_with("decalc", [], allow_destructive=True)
-
-
-async def test_decalc_alias_still_dispatches_decalc_command():
-    coordinator = _mock_coordinator()
-    hass = _hass_with_coordinator(coordinator)
-    _register_services(hass)
-    handler = hass.services._registered[(DOMAIN, "decalc")]["handler"]
     call = MagicMock()
     call.data = {"config_entry_id": "test_entry_id"}
     await handler(call)

--- a/tests/test_brew_service.py
+++ b/tests/test_brew_service.py
@@ -2,9 +2,10 @@
 
 The ``jura.brew`` service gains a friendly ``product`` path (build the
 ``@TP:`` payload from the machine's product table) while keeping the
-legacy raw ``recipe`` path intact. ``jura.descale`` is the renamed UI
-service; ``jura.decalc`` stays as a backwards-compat alias. Both map to
-the library's ``decalc`` command. No machine I/O — run_command is mocked.
+legacy raw ``recipe`` path intact. ``jura.descale`` is the user-facing
+service name and maps to the library's ``decalc`` command; the legacy
+``jura.decalc`` service alias has been removed. No machine I/O —
+run_command is mocked.
 """
 
 from __future__ import annotations

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -115,3 +115,80 @@ async def test_write_setting_backend_error_raises_update_failed(mock_backend, fa
     mock_backend.write_setting.side_effect = JuraBackendError("rejection")
     with pytest.raises(UpdateFailed):
         await coordinator.write_setting("hardness", "18")
+
+
+# ---------------------------------------------------------------------------
+# Persistent per-product brew preferences
+# ---------------------------------------------------------------------------
+
+
+async def test_async_load_brew_prefs_starts_empty(mock_backend, fake_config_entry):
+    coordinator = _make_coordinator(mock_backend, fake_config_entry)
+    await coordinator.async_load_brew_prefs()
+    assert coordinator.brew_prefs == {}
+
+
+async def test_save_brew_prefs_is_noop_without_a_store(mock_backend, fake_config_entry):
+    """Before async_load_brew_prefs wires a Store, saving must not raise."""
+    coordinator = _make_coordinator(mock_backend, fake_config_entry)
+    await coordinator.save_brew_prefs()  # must not raise
+    assert coordinator.brew_prefs == {}
+
+
+async def test_set_brew_param_updates_selection_and_prefs(mock_backend, fake_config_entry):
+    """A param change stages the value AND records it for the current product."""
+    coordinator = _make_coordinator(mock_backend, fake_config_entry)
+    await coordinator.async_load_brew_prefs()
+    coordinator.select_brew_product("03")
+    coordinator.set_brew_param("water_ml", 130)
+    assert coordinator.brew_selection["water_ml"] == 130
+    assert coordinator.brew_prefs["03"]["water_ml"] == 130
+
+
+def test_set_brew_param_factory_default_records_none(mock_backend, fake_config_entry):
+    coordinator = _make_coordinator(mock_backend, fake_config_entry)
+    coordinator.select_brew_product("03")
+    coordinator.set_brew_param("water_ml", 130)
+    coordinator.set_brew_param("water_ml", None)  # Factory Default
+    assert coordinator.brew_selection["water_ml"] is None
+    assert coordinator.brew_prefs["03"]["water_ml"] is None
+
+
+def test_select_brew_product_loads_saved_prefs_into_selection(mock_backend, fake_config_entry):
+    """Switching product hydrates the staged selection from that product's prefs."""
+    coordinator = _make_coordinator(mock_backend, fake_config_entry)
+    coordinator.brew_prefs["03"] = {"strength": 2, "water_ml": 130, "temp": 1}
+    coordinator.select_brew_product("03")
+    assert coordinator.brew_selection == {
+        "product": "03",
+        "strength": 2,
+        "water_ml": 130,
+        "temp": 1,
+    }
+
+
+def test_select_brew_product_without_prefs_is_all_factory_default(mock_backend, fake_config_entry):
+    coordinator = _make_coordinator(mock_backend, fake_config_entry)
+    coordinator.brew_selection.update(strength=4, water_ml=120, temp=2)
+    coordinator.select_brew_product("03")  # no saved prefs for 03
+    assert coordinator.brew_selection == {
+        "product": "03",
+        "strength": None,
+        "water_ml": None,
+        "temp": None,
+    }
+
+
+async def test_brew_prefs_persist_across_coordinator_restarts(mock_backend, fake_config_entry):
+    """The net contract: set a pref, restart (new coordinator), it's remembered."""
+    c1 = _make_coordinator(mock_backend, fake_config_entry)
+    await c1.async_load_brew_prefs()
+    c1.select_brew_product("03")
+    c1.set_brew_param("water_ml", 130)
+    await c1.save_brew_prefs()
+
+    c2 = _make_coordinator(mock_backend, fake_config_entry)
+    await c2.async_load_brew_prefs()
+    assert c2.brew_prefs["03"]["water_ml"] == 130
+    c2.select_brew_product("03")
+    assert c2.brew_selection["water_ml"] == 130

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -106,7 +106,7 @@ def test_counter_sensor_is_diagnostic_and_named_with_cycles_prefix(sample_snapsh
 def test_percent_sensor_is_default_category_and_named_with_service_prefix(sample_snapshot, fake_config_entry):
     s = PercentSensor(_make_coordinator(sample_snapshot), fake_config_entry, "decalc")
     assert s.entity_category is None
-    assert s.name == "Service decalc level"
+    assert s.name == "Service descale level"
 
 
 def test_brew_counter_named_with_brew_prefix(sample_snapshot, fake_config_entry):


### PR DESCRIPTION
Implements #5 — brewing products from the dashboard instead of raw `@TP:` recipe codes.

## What this adds

A compact brew **control panel** (shared per machine, not per product):

- a **Product** select + **Strength / Water / Temperature** selects (each with a *Factory Default* sentinel) + a single **Brew** button
- a product-aware path that builds the full 16-byte `@TP:` payload from the machine's bundled XML profile
- per-product preferences that persist across restarts (set *Coffee = 130 ml* once → remembered)

Everything is decoded from the per-machine XML that `jura_connect` already vendors — no hardcoded recipe tables.

## Live-validated on a JURA E6

Two payload vectors were validated by actually brewing on hardware:

- default Espresso → `@TP:02000809000002000100000000000000`
- Coffee, strength 2, 130 ml, Normal → `@TP:0300021A000001000100000000000000`

## Two recipe fixes included

- **Products without an `Active` attribute are brewable.** The J.O.E. app defaults the flag to true (`XMLParser.java`: `boolean z7 = true`) and only hides explicit `Active="false"`. This restores Milk Foam / Cafe Barista / Barista Lungo on the E6, and products on ~42 other models that never set `Active="true"`.
- **Milk-foam (F6) and bypass (F10) defaults are now encoded** (previously left at `0x00`).

## Notes / open questions

- Synced with current `main` (async coordinator setup, offline-on-every-poll, dynamic per-recipe counters) — conflict-free.
- The F6/F10 defaults are XML-derived, not yet live-brewed — happy to confirm on hardware.
- Per #5: still happy to move the payload/param logic into the `jura_connect` library and keep this component thin if you prefer — your call on the API.
- Tests: 184 passing (HA stubbed via the test conftest), `ruff check` + `ruff format` clean. Happy to squash or split into focused lib + component PRs if that's easier to review.
