### PR TITLE
jura: offload article-number lookup off the event loop

### DIFF
--- a/custom_components/jura/backends/jura.py
+++ b/custom_components/jura/backends/jura.py
@@ -337,9 +337,18 @@ async def probe_address(address: str, port: int = 51515) -> bool:
     return await asyncio.to_thread(_do)
 
 
-def machine_type_from_article(article_number: int | None) -> str | None:
-    """Map a UDP-discovered article number to an EF code, if known."""
+async def machine_type_from_article(article_number: int | None) -> str | None:
+    """Map a UDP-discovered article number to an EF code, if known.
+
+    ``lookup_by_article_number`` reads the bundled machine catalogue off
+    disk, so the lookup runs in a worker thread to keep the config-flow
+    event loop unblocked — the same convention as the other helpers here.
+    """
     if not article_number:
         return None
-    entry = lookup_by_article_number(article_number)
-    return entry.ef_code if entry else None
+
+    def _do() -> str | None:
+        entry = lookup_by_article_number(article_number)
+        return entry.ef_code if entry else None
+
+    return await asyncio.to_thread(_do)

--- a/custom_components/jura/config_flow.py
+++ b/custom_components/jura/config_flow.py
@@ -142,7 +142,7 @@ class JuraConfigFlow(ConfigFlow, domain=DOMAIN):
                     # Best-effort: derive the EF code from the discovery
                     # broadcast's article number so the machine_type
                     # step can default to the right value.
-                    self._auto_machine_type = machine_type_from_article(machine.article_number)
+                    self._auto_machine_type = await machine_type_from_article(machine.article_number)
                     return await self.async_step_pair_progress()
             return await self.async_step_manual()
 

--- a/tests/test_backends/test_jura.py
+++ b/tests/test_backends/test_jura.py
@@ -13,7 +13,11 @@ import pytest
 jura_connect = pytest.importorskip("jura_connect")
 simulator = pytest.importorskip("jura_connect.simulator")
 
-from custom_components.jura.backends.jura import JuraConnectBackend  # noqa: E402
+from custom_components.jura.backends import jura as jura_backend  # noqa: E402
+from custom_components.jura.backends.jura import (  # noqa: E402
+    JuraConnectBackend,
+    machine_type_from_article,
+)
 
 
 @pytest.fixture
@@ -193,3 +197,37 @@ async def test_run_named_status(running_simulator):
     result = await backend.run_named("status")
     assert result["name"] == "status"
     assert "active_alerts" in result["value"]
+
+
+async def test_machine_type_from_article_none_returns_none():
+    """A missing article number resolves to no EF code without touching disk."""
+    assert await machine_type_from_article(None) is None
+
+
+async def test_machine_type_from_article_offloads_blocking_lookup(monkeypatch):
+    """Regression: the catalogue lookup reads JOE_MACHINES.TXT off disk and
+    used to run inline in the config-flow event loop, which Home Assistant
+    flags as a blocking call. It must be a coroutine that offloads the lookup
+    to a worker thread.
+    """
+    import inspect
+    import threading
+
+    assert inspect.iscoroutinefunction(machine_type_from_article)
+
+    class _Entry:
+        ef_code = "EF545"
+
+    lookup_threads: list[threading.Thread] = []
+
+    def _fake_lookup(_n):
+        lookup_threads.append(threading.current_thread())
+        return _Entry()
+
+    monkeypatch.setattr(jura_backend, "lookup_by_article_number", _fake_lookup)
+    assert await machine_type_from_article(15001) == "EF545"
+    # The catalogue read must have run on a worker thread, not the loop.
+    assert lookup_threads and lookup_threads[0] is not threading.current_thread()
+
+    monkeypatch.setattr(jura_backend, "lookup_by_article_number", lambda _n: None)
+    assert await machine_type_from_article(15001) is None


### PR DESCRIPTION
During discovery-based setup, Home Assistant logs *"Detected blocking call to `read_text`/`open` … inside the event loop by custom integration 'jura'"* and points here to file a bug.

Root cause: `machine_type_from_article()` calls `jura_connect.lookup_by_article_number()`, which reads the bundled `JOE_MACHINES.TXT` catalogue from disk; `config_flow.async_step_select()` invoked it directly on the event loop.

Fix: make the helper `async` and funnel the lookup through `asyncio.to_thread()` — the same convention `discover_machines()` and `probe_address()` already use — and `await` it at the call site. No behaviour change.

Regression test asserts the helper is a coroutine **and** that the lookup actually runs on a worker thread. Full suite: 144 passed; `ruff check` + `ruff format` clean.

Two notes:
- `JuraConnectBackend.__init__` → `_resolve_profile_and_name()` → `load_profile()` is the same pattern (disk read, constructed from async context in `coordinator.py`/`config_flow.py`). Happy to send a follow-up PR if you want it handled the same way.
- Version left untouched — `manifest.json` (0.8.0) and `pyproject.toml` (0.7.5) are currently out of sync, so I'd rather you decide the bump.

Found while setting this up against a Z10 (EF545) — works great, thanks for the integration!
