### PR TITLE
feat: milk and milk-foam brew axes (F5/F6) over jura_connect 0.11.0

### DIFF
--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -14,6 +14,8 @@ try:
     from homeassistant.helpers import entity_registry as er
     from jura_connect import (
         KIND_COFFEE_STRENGTH,
+        KIND_MILK_AMOUNT,
+        KIND_MILK_FOAM_AMOUNT,
         KIND_TEMPERATURE,
         KIND_WATER_AMOUNT,
         ProductDef,
@@ -69,6 +71,8 @@ if _HAS_HOMEASSISTANT:
         "strength": KIND_COFFEE_STRENGTH,
         "water_ml": KIND_WATER_AMOUNT,
         "temperature": KIND_TEMPERATURE,
+        "milk_s": KIND_MILK_AMOUNT,
+        "milk_foam_s": KIND_MILK_FOAM_AMOUNT,
     }
 
     _BASE_TARGET_SCHEMA = vol.Schema(
@@ -90,6 +94,8 @@ if _HAS_HOMEASSISTANT:
             vol.Optional("strength"): vol.Coerce(int),
             vol.Optional("water_ml"): vol.Coerce(int),
             vol.Optional("temperature"): vol.Coerce(int),
+            vol.Optional("milk_s"): vol.Coerce(int),
+            vol.Optional("milk_foam_s"): vol.Coerce(int),
         }
     )
 

--- a/custom_components/jura/brew/prefs.py
+++ b/custom_components/jura/brew/prefs.py
@@ -1,11 +1,11 @@
 """Pure (framework-free) per-product brew-preference helpers.
 
-A *brew preference* is the remembered strength / water / temperature for a
-single product, keyed by the product's hex Code (e.g. ``"03"``). The on-disk /
-in-memory shape is::
+A *brew preference* is the remembered strength / water / temperature / milk /
+milk-foam for a single product, keyed by the product's hex Code (e.g. ``"03"``).
+The on-disk / in-memory shape is::
 
     brew_prefs: dict[str, dict] = {
-        "03": {"strength": 2, "water_ml": 130, "temp": None},
+        "03": {"strength": 2, "water_ml": 130, "temp": None, "milk_s": None, "milk_foam_s": 12},
         ...
     }
 
@@ -27,8 +27,10 @@ module only models the component's remembered-preference shape.
 
 from __future__ import annotations
 
-# The three adjustable recipe axes a preference can pin per product.
-BREW_PARAMS: tuple[str, ...] = ("strength", "water_ml", "temp")
+# The adjustable recipe axes a preference can pin per product. Milk and milk
+# foam are dispensing times in seconds — that is the unit the machines expose
+# (MinMax args on the F5/F6 recipe bytes), not millilitres.
+BREW_PARAMS: tuple[str, ...] = ("strength", "water_ml", "temp", "milk_s", "milk_foam_s")
 
 
 def product_prefs(brew_prefs: dict[str, dict], code: str) -> dict[str, int | None]:

--- a/custom_components/jura/button.py
+++ b/custom_components/jura/button.py
@@ -1,7 +1,7 @@
 """Button platform: a single "Brew" button driving the brew control panel.
 
 Pressing the button PHYSICALLY brews a drink. It reads the machine-wide
-``coordinator.brew_selection`` (product + optional strength/water/temperature
+``coordinator.brew_selection`` (product + optional strength/water/temperature/milk
 staged by the brew selects), builds the bare recipe blob from the product's
 definition via the ``jura_connect`` library — a ``None`` parameter falls back
 to that product's XML default — and dispatches the library's ``brew`` command
@@ -16,7 +16,13 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from jura_connect import KIND_COFFEE_STRENGTH, KIND_TEMPERATURE, KIND_WATER_AMOUNT
+from jura_connect import (
+    KIND_COFFEE_STRENGTH,
+    KIND_MILK_AMOUNT,
+    KIND_MILK_FOAM_AMOUNT,
+    KIND_TEMPERATURE,
+    KIND_WATER_AMOUNT,
+)
 
 from .const import DOMAIN
 from .coordinator import JuraCoordinator
@@ -29,6 +35,8 @@ _SELECTION_KINDS: dict[str, str] = {
     "strength": KIND_COFFEE_STRENGTH,
     "water_ml": KIND_WATER_AMOUNT,
     "temp": KIND_TEMPERATURE,
+    "milk_s": KIND_MILK_AMOUNT,
+    "milk_foam_s": KIND_MILK_FOAM_AMOUNT,
 }
 
 

--- a/custom_components/jura/coordinator.py
+++ b/custom_components/jura/coordinator.py
@@ -157,11 +157,14 @@ class JuraCoordinator(DataUpdateCoordinator[MachineSnapshot]):
             "strength": None,
             "water_ml": None,
             "temp": None,
+            "milk_s": None,
+            "milk_foam_s": None,
         }
         if self.brew_profile is not None and self.brew_profile.products:
             self.brew_selection["product"] = f"{self.brew_profile.products[0].code:02X}"
         # Persistent per-product brew preferences: product Code (2-hex string) ->
-        # {"strength"|"water_ml"|"temp": int | None}, where ``None`` == Factory
+        # {"strength"|"water_ml"|"temp"|"milk_s"|"milk_foam_s": int | None},
+        # where ``None`` == Factory
         # Default. Loaded from disk by ``async_load_brew_prefs`` at setup and
         # written back (debounced) by ``save_brew_prefs``.
         self.brew_prefs: dict[str, dict[str, int | None]] = {}

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -1,13 +1,17 @@
 {
     "domain": "jura",
     "name": "Jura Connect",
-    "codeowners": ["@makefu"],
+    "codeowners": [
+        "@makefu"
+    ],
     "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/makefu/jura-connect-hass",
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
-    "requirements": ["jura_connect>=0.10.0"],
-    "version": "0.9.0"
+    "requirements": [
+        "jura_connect>=0.11.0"
+    ],
+    "version": "0.10.0"
 }

--- a/custom_components/jura/select.py
+++ b/custom_components/jura/select.py
@@ -7,8 +7,8 @@ Two families of selects live here:
   ``step_slider`` settings (hardness) are handled by the ``number``
   platform instead.
 * **Brew control panel** — a small, machine-wide set that stages the
-  *next* brew: a product picker plus strength / water / temperature
-  selects. Each parameter select carries a ``"Factory Default"`` option
+  *next* brew: a product picker plus strength / water / temperature /
+  milk / milk-foam selects. Each parameter select carries a ``"Factory Default"`` option
   (meaning "let the recipe builder use the product's XML default" — it does
   NOT mean "use the machine's own configured setting", which JURA WiFi has
   no mechanism for) and recomputes its options from whichever product is
@@ -29,6 +29,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from jura_connect import (
     KIND_COFFEE_STRENGTH,
+    KIND_MILK_AMOUNT,
+    KIND_MILK_FOAM_AMOUNT,
     KIND_TEMPERATURE,
     KIND_WATER_AMOUNT,
     ProductParam,
@@ -107,6 +109,10 @@ def _brew_select_entities(coordinator: JuraCoordinator, config_entry: ConfigEntr
         entities.append(BrewWaterSelect(coordinator, config_entry))
     if any(product.param(KIND_TEMPERATURE) for product in profile.products):
         entities.append(BrewTempSelect(coordinator, config_entry))
+    if any(product.param(KIND_MILK_AMOUNT) for product in profile.products):
+        entities.append(BrewMilkSelect(coordinator, config_entry))
+    if any(product.param(KIND_MILK_FOAM_AMOUNT) for product in profile.products):
+        entities.append(BrewMilkFoamSelect(coordinator, config_entry))
     return entities
 
 
@@ -311,27 +317,23 @@ class BrewTempSelect(_ItemBrewSelect):
     _name_suffix = "Temperature"
 
 
-class BrewWaterSelect(_BrewParamSelect):
-    """Water amount (mL) for the next brew, or Factory Default.
+class _RangeBrewSelect(_BrewParamSelect):
+    """Brew parameter backed by a numeric ``min..max`` range (water/milk/foam).
 
     A select (rather than a number) so it can carry the ``Factory Default``
     sentinel; its options are the product's ``min..max`` range in ``step``
     increments.
     """
 
-    _param_kind = KIND_WATER_AMOUNT
-    _selection_key = "water_ml"
-    _name_suffix = "Water"
-
     @staticmethod
-    def _ml_range(param: ProductParam) -> range:
+    def _value_range(param: ProductParam) -> range:
         low = param.minimum if param.minimum is not None else 0
         high = param.maximum if param.maximum is not None else low
         step = param.step or 1
         return range(low, high + 1, step)
 
     def _value_options(self, param: ProductParam) -> list[str]:
-        return [str(ml) for ml in self._ml_range(param)]
+        return [str(value) for value in self._value_range(param)]
 
     def _value_for_option(self, param: ProductParam, option: str) -> int | None:
         try:
@@ -341,3 +343,31 @@ class BrewWaterSelect(_BrewParamSelect):
 
     def _option_for_value(self, param: ProductParam, value: int) -> str | None:
         return str(value)
+
+
+class BrewWaterSelect(_RangeBrewSelect):
+    """Water amount (mL) for the next brew, or Factory Default."""
+
+    _param_kind = KIND_WATER_AMOUNT
+    _selection_key = "water_ml"
+    _name_suffix = "Water"
+
+
+class BrewMilkSelect(_RangeBrewSelect):
+    """Milk dispensing time (seconds) for the next brew, or Factory Default.
+
+    JURA machines meter milk by pump time, not volume — the F5 recipe byte
+    carries seconds, so that is the unit exposed here.
+    """
+
+    _param_kind = KIND_MILK_AMOUNT
+    _selection_key = "milk_s"
+    _name_suffix = "Milk"
+
+
+class BrewMilkFoamSelect(_RangeBrewSelect):
+    """Milk foam dispensing time (seconds) for the next brew, or Factory Default."""
+
+    _param_kind = KIND_MILK_FOAM_AMOUNT
+    _selection_key = "milk_foam_s"
+    _name_suffix = "Milk Foam"

--- a/custom_components/jura/services.yaml
+++ b/custom_components/jura/services.yaml
@@ -46,7 +46,7 @@ brew:
   name: Brew
   description: >-
     Brew a drink. Pick a product by name (optionally overriding
-    strength/water/temperature), or pass a raw recipe payload. This
+    strength/water/temperature/milk/milk-foam), or pass a raw recipe payload. This
     PHYSICALLY brews a drink on the machine.
   fields:
     config_entry_id:
@@ -97,6 +97,29 @@ brew:
         number:
           min: 0
           max: 3
+          mode: box
+    milk_s:
+      name: Milk
+      description: >-
+        Optional milk dispensing time in seconds (JURA machines meter milk by
+        pump time, not volume). Omit for the product's factory default.
+        Clamped to the product's valid range.
+      selector:
+        number:
+          min: 0
+          max: 120
+          unit_of_measurement: s
+          mode: box
+    milk_foam_s:
+      name: Milk foam
+      description: >-
+        Optional milk-foam dispensing time in seconds. Omit for the product's
+        factory default. Clamped to the product's valid range.
+      selector:
+        number:
+          min: 0
+          max: 120
+          unit_of_measurement: s
           mode: box
     recipe:
       name: Recipe (advanced)

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782990151,
-        "narHash": "sha256-pwh482uhflktugF7BNawtd99BjbZ9yfUAFHiZ8E8Hf8=",
+        "lastModified": 1783344391,
+        "narHash": "sha256-f5I1EzyIBeAYHYlve6mRbn2pyhEes8GiGczEP7GO8+o=",
         "owner": "makefu",
         "repo": "jura-connect",
-        "rev": "13b7c680fc95f44a4c03f8b88fc85ac1248162cf",
+        "rev": "3fe6beb0489be36f2a3266f4ea7f02892c39fa29",
         "type": "github"
       },
       "original": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-jura-connect"
-version = "0.9.0"
+version = "0.10.0"
 requires-python = ">=3.13"
 dependencies = [
-    "jura_connect>=0.10.0",
+    "jura_connect>=0.11.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_brew_platform.py
+++ b/tests/test_brew_platform.py
@@ -1,7 +1,7 @@
 """Tests for the compact brew "control panel".
 
-The brew UX is five entities shared across the whole machine (not per
-product): a product select, strength/water/temperature selects (each
+The brew UX is seven entities shared across the whole machine (not per
+product): a product select, strength/water/temperature/milk/milk-foam selects (each
 carrying a "Factory Default" sentinel), and a single brew button.
 Selections are staged on ``coordinator.brew_selection``; the button reads
 them and builds the recipe via the ``jura_connect`` library. Per-product
@@ -26,6 +26,7 @@ jura_connect = pytest.importorskip("jura_connect")
 
 from jura_connect import (  # noqa: E402
     KIND_COFFEE_STRENGTH,
+    KIND_MILK_FOAM_AMOUNT,
     KIND_TEMPERATURE,
     KIND_WATER_AMOUNT,
     load_profile,
@@ -43,6 +44,8 @@ from custom_components.jura.const import (  # noqa: E402
 )
 from custom_components.jura.coordinator import JuraCoordinator  # noqa: E402
 from custom_components.jura.select import (  # noqa: E402
+    BrewMilkFoamSelect,
+    BrewMilkSelect,
     BrewProductSelect,
     BrewStrengthSelect,
     BrewTempSelect,
@@ -98,6 +101,8 @@ def test_coordinator_seeds_first_product_and_default_params():
         "strength": None,
         "water_ml": None,
         "temp": None,
+        "milk_s": None,
+        "milk_foam_s": None,
     }
     assert coordinator.selected_product().name == "espresso"
 
@@ -147,6 +152,8 @@ async def test_product_select_loads_saved_prefs_into_param_selects():
         "strength": 2,
         "water_ml": 130,
         "temp": 1,
+        "milk_s": None,
+        "milk_foam_s": None,
     }
     assert strength.current_option == "2"
     assert water.current_option == "130"
@@ -284,6 +291,64 @@ async def test_temp_select_set_and_factory_default():
 
 
 # ---------------------------------------------------------------------------
+# Milk / milk-foam selects
+# ---------------------------------------------------------------------------
+
+
+async def test_milk_foam_select_options_from_range():
+    coordinator = _coordinator()
+    entry = _entry()
+    product = BrewProductSelect(coordinator, entry)
+    foam = BrewMilkFoamSelect(coordinator, entry)
+    # espresso (the seeded product) has no milk-foam parameter.
+    assert foam.available is False
+    assert foam.options == [FACTORY_DEFAULT]
+    # cappuccino: 1..45 s step 1.
+    await product.async_select_option("cappuccino")
+    assert foam.available is True
+    assert foam.options == [FACTORY_DEFAULT, *[str(v) for v in range(1, 46)]]
+    assert foam.current_option == FACTORY_DEFAULT
+    assert foam.unique_id.endswith("brew_milk_foam_s")
+
+
+async def test_milk_selects_gate_per_product():
+    """Milk vs foam availability tracks what the staged product exposes.
+
+    On the EF1091, cappuccino has only a foam time and the plain milk
+    product has only a milk time — each select must be available exactly
+    where its parameter exists.
+    """
+    coordinator = _coordinator()
+    entry = _entry()
+    product = BrewProductSelect(coordinator, entry)
+    milk = BrewMilkSelect(coordinator, entry)
+    foam = BrewMilkFoamSelect(coordinator, entry)
+
+    await product.async_select_option("cappuccino")
+    assert milk.available is False
+    assert foam.available is True
+
+    await product.async_select_option("milk")
+    assert milk.available is True
+    assert foam.available is False
+    assert milk.options == [FACTORY_DEFAULT, *[str(v) for v in range(1, 46)]]
+
+
+async def test_milk_foam_set_and_factory_default():
+    coordinator = _coordinator()
+    entry = _entry()
+    product = BrewProductSelect(coordinator, entry)
+    foam = BrewMilkFoamSelect(coordinator, entry)
+    await product.async_select_option("cappuccino")
+    await foam.async_select_option("12")
+    assert coordinator.brew_selection["milk_foam_s"] == 12
+    assert foam.current_option == "12"
+    await foam.async_select_option(FACTORY_DEFAULT)
+    assert coordinator.brew_selection["milk_foam_s"] is None
+    assert foam.current_option == FACTORY_DEFAULT
+
+
+# ---------------------------------------------------------------------------
 # Brew button
 # ---------------------------------------------------------------------------
 
@@ -334,8 +399,24 @@ async def test_button_press_coffee_override_vector_via_selection_path():
     coordinator.run_command.assert_awaited_once_with("brew", [expected], allow_destructive=True)
 
 
+async def test_button_press_cappuccino_milk_foam_override_vector():
+    """Select cappuccino + foam 12 s -> the F6 override lands in the recipe."""
+    coordinator = _coordinator()
+    entry = _entry()
+    product = BrewProductSelect(coordinator, entry)
+    foam = BrewMilkFoamSelect(coordinator, entry)
+    button = JuraBrewButton(coordinator, entry)
+
+    await product.async_select_option("cappuccino")
+    await foam.async_select_option("12")
+    await button.async_press()
+
+    expected = _recipe(0x04, {KIND_MILK_FOAM_AMOUNT: 12})
+    coordinator.run_command.assert_awaited_once_with("brew", [expected], allow_destructive=True)
+
+
 # ---------------------------------------------------------------------------
-# Platform setup: the five-entity control panel on a real EF1091
+# Platform setup: the seven-entity control panel on a real EF1091
 # ---------------------------------------------------------------------------
 
 
@@ -363,11 +444,18 @@ async def test_select_setup_builds_control_panel_not_per_product():
     added = await _setup("custom_components.jura.select")
     brew = [e for e in added if _is_brew_select(e)]
     brew_names = {e.name for e in brew}
-    assert brew_names == {"Brew Product", "Brew Strength", "Brew Water", "Brew Temperature"}
+    assert brew_names == {
+        "Brew Product",
+        "Brew Strength",
+        "Brew Water",
+        "Brew Temperature",
+        "Brew Milk",
+        "Brew Milk Foam",
+    }
     # Setting selects are still present...
     assert any(_is_setting_select(e) for e in added)
     # ...but there is exactly one of each brew select (no per-product explosion).
-    assert len(brew) == 4
+    assert len(brew) == 6
 
 
 async def test_button_setup_creates_single_brew_button():
@@ -383,8 +471,8 @@ async def test_number_setup_has_no_per_product_brew_water():
     assert not any("brew" in (e.unique_id or "") for e in added)
 
 
-async def test_ef1091_creates_exactly_five_brew_entities():
+async def test_ef1091_creates_exactly_seven_brew_entities():
     selects = await _setup("custom_components.jura.select")
     buttons = await _setup("custom_components.jura.button")
     brew_selects = [e for e in selects if _is_brew_select(e)]
-    assert len(brew_selects) + len(buttons) == 5
+    assert len(brew_selects) + len(buttons) == 7

--- a/tests/test_brew_prefs.py
+++ b/tests/test_brew_prefs.py
@@ -1,6 +1,7 @@
 """Pure (framework-free) per-product brew-preference helpers.
 
-A *brew preference* is the remembered strength / water / temperature for one
+A *brew preference* is the remembered strength / water / temperature / milk /
+milk-foam for one
 product, keyed by its hex Code. ``None`` for a parameter means Factory Default
 (send the product's XML default; pass ``None`` to the ``jura_connect`` library
 builder ``ProductDef.build_recipe_hex``). These helpers only touch plain dicts,
@@ -17,17 +18,29 @@ from custom_components.jura.brew import (
 )
 
 
-def test_brew_params_are_the_three_recipe_axes():
-    assert BREW_PARAMS == ("strength", "water_ml", "temp")
+def test_brew_params_are_the_five_recipe_axes():
+    assert BREW_PARAMS == ("strength", "water_ml", "temp", "milk_s", "milk_foam_s")
 
 
 def test_product_prefs_missing_product_is_all_factory_default():
-    assert product_prefs({}, "03") == {"strength": None, "water_ml": None, "temp": None}
+    assert product_prefs({}, "03") == {
+        "strength": None,
+        "water_ml": None,
+        "temp": None,
+        "milk_s": None,
+        "milk_foam_s": None,
+    }
 
 
 def test_product_prefs_fills_missing_params_with_none():
     prefs = {"03": {"water_ml": 130}}
-    assert product_prefs(prefs, "03") == {"strength": None, "water_ml": 130, "temp": None}
+    assert product_prefs(prefs, "03") == {
+        "strength": None,
+        "water_ml": 130,
+        "temp": None,
+        "milk_s": None,
+        "milk_foam_s": None,
+    }
 
 
 def test_remember_then_load_reproduces_value():
@@ -53,10 +66,12 @@ def test_remember_is_per_product_isolated():
 
 
 def test_selection_for_product_includes_product_code():
-    prefs = {"03": {"strength": 2, "water_ml": 130, "temp": 1}}
+    prefs = {"03": {"strength": 2, "water_ml": 130, "temp": 1, "milk_foam_s": 12}}
     assert selection_for_product(prefs, "03") == {
         "product": "03",
         "strength": 2,
         "water_ml": 130,
         "temp": 1,
+        "milk_s": None,
+        "milk_foam_s": 12,
     }

--- a/tests/test_brew_service.py
+++ b/tests/test_brew_service.py
@@ -20,6 +20,7 @@ jura_connect = pytest.importorskip("jura_connect")
 
 from jura_connect import (  # noqa: E402
     KIND_COFFEE_STRENGTH,
+    KIND_MILK_FOAM_AMOUNT,
     KIND_TEMPERATURE,
     KIND_WATER_AMOUNT,
     load_profile,
@@ -32,6 +33,8 @@ _PROFILE = load_profile("EF1091")
 _DOPPIO = next(p for p in _PROFILE.products if p.name == "espresso_doppio")
 _DEFAULT_RECIPE = _DOPPIO.build_recipe_hex({})
 _OVERRIDE_RECIPE = _DOPPIO.build_recipe_hex({KIND_COFFEE_STRENGTH: 2, KIND_WATER_AMOUNT: 130, KIND_TEMPERATURE: 1})
+_CAPPUCCINO = next(p for p in _PROFILE.products if p.name == "cappuccino")
+_MILK_FOAM_RECIPE = _CAPPUCCINO.build_recipe_hex({KIND_MILK_FOAM_AMOUNT: 12})
 
 
 def _hass_with_coordinator(coordinator) -> MagicMock:
@@ -116,6 +119,21 @@ async def test_brew_by_product_with_overrides():
     }
     await _brew_handler(hass)(call)
     coordinator.run_command.assert_awaited_once_with("brew", [_OVERRIDE_RECIPE], allow_destructive=True)
+
+
+async def test_brew_by_product_with_milk_foam_override():
+    """The milk_foam_s service field lands on the F6 recipe byte."""
+    coordinator = _mock_coordinator()
+    hass = _hass_with_coordinator(coordinator)
+    _register_services(hass)
+    call = MagicMock()
+    call.data = {
+        "config_entry_id": "test_entry_id",
+        "product": "cappuccino",
+        "milk_foam_s": 12,
+    }
+    await _brew_handler(hass)(call)
+    coordinator.run_command.assert_awaited_once_with("brew", [_MILK_FOAM_RECIPE], allow_destructive=True)
 
 
 async def test_brew_by_product_code_resolves():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -336,6 +336,8 @@ def test_select_brew_product_loads_saved_prefs_into_selection(mock_backend, fake
         "strength": 2,
         "water_ml": 130,
         "temp": 1,
+        "milk_s": None,
+        "milk_foam_s": None,
     }
 
 
@@ -348,6 +350,8 @@ def test_select_brew_product_without_prefs_is_all_factory_default(mock_backend, 
         "strength": None,
         "water_ml": None,
         "temp": None,
+        "milk_s": None,
+        "milk_foam_s": None,
     }
 
 

--- a/www/jura-brew-card.js
+++ b/www/jura-brew-card.js
@@ -20,6 +20,8 @@
  *   strength: select.kuche_kaffeebert_brew_strength
  *   water: select.kuche_kaffeebert_brew_water
  *   temperature: select.kuche_kaffeebert_brew_temperature
+ *   milk: select.kuche_kaffeebert_brew_milk
+ *   milk_foam: select.kuche_kaffeebert_brew_milk_foam
  *   button: button.kuche_kaffeebert_brew
  *   status: sensor.kuche_kaffeebert_status
  *   connectivity: binary_sensor.kuche_kaffeebert_connectivity
@@ -40,6 +42,8 @@ const PARAM_ROWS = [
   { key: "strength", label: "Strength", icon: "mdi:coffee" },
   { key: "water", label: "Water", icon: "mdi:cup-water", unit: " mL" },
   { key: "temperature", label: "Temperature", icon: "mdi:thermometer" },
+  { key: "milk", label: "Milk", icon: "mdi:beer-outline", unit: " s" },
+  { key: "milk_foam", label: "Milk Foam", icon: "mdi:chart-bubble", unit: " s" },
 ];
 
 // Map a raw status string to a coffee-machine "mood": drives the banner colour
@@ -121,6 +125,8 @@ class JuraBrewCard extends HTMLElement {
       strength: pick(cfg.strength, "select", "_brew_strength"),
       water: pick(cfg.water, "select", "_brew_water"),
       temperature: pick(cfg.temperature, "select", "_brew_temperature"),
+      milk: pick(cfg.milk, "select", "_brew_milk"),
+      milk_foam: pick(cfg.milk_foam, "select", "_brew_milk_foam"),
       button: cfg.button || pick(null, "button", "_brew"),
       status: pick(cfg.status, "sensor", "_status"),
       connectivity: pick(cfg.connectivity, "binary_sensor", "_connectivity"),


### PR DESCRIPTION
Adds **Brew Milk** and **Brew Milk Foam** to the brew control panel — the F5/F6 recipe axes, staged in seconds (the unit machines meter milk by: pump time, not volume).

Follows the panel's existing thin-wiring pattern end to end:

- Two new range selects (like Brew Water) with options from the product XML MinMax ranges, leading with Factory Default. They gate per product — e.g. on the S8, cappuccino exposes only foam time and the plain milk product only milk time, so each select is available exactly where its parameter exists.
- Values persist per product via the existing `brew_prefs` store and hydrate on product switch.
- The brew button and the `jura.brew` service (new optional `milk_s` / `milk_foam_s` fields) pass them to `build_recipe_hex` — all byte encoding stays in the library.
- The brew card grows Milk / Milk Foam sliders that appear only when the staged product supports them (same row-drop mechanism as the other axes).

Housekeeping per AGENTS.md: `jura_connect` floor 0.10.0 → 0.11.0 (settable milk amount landed in #7 / v0.11.0), component version 0.9.0 → 0.10.0, manifest and pyproject kept in lockstep.

Tests: 198 pass (`pytest tests/`), including new coverage for range options, per-product gating, prefs round-trip, the button recipe vector (`KIND_MILK_FOAM_AMOUNT` override against the real EF1091 profile) and the service fields. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
