### PR TITLE
jura: support Z10 profiles without regional mislabeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TT237W series). Built on the reverse-engineered
 directly to the machine's WiFi dongle on TCP/51515. No cloud, no vendor
 account.
 
-Requires `jura_connect>=0.9.1`. The integration ships the Python dependency
+Requires `jura_connect>=0.13.0`. The integration ships the Python dependency
 declaration; Nix users get it pinned via the flake input.
 
 ## Features

--- a/custom_components/jura/backends/jura.py
+++ b/custom_components/jura/backends/jura.py
@@ -51,14 +51,17 @@ def _resolve_profile_and_name(machine_type: str | None) -> tuple[MachineProfile 
     except KeyError:
         _LOGGER.warning("unknown machine_type %r, falling through to baseline", machine_type)
         return None, None
-    # Friendly-name lookup: walk the catalogue once.
-    friendly: str | None = None
+    # Multiple regional variants can share one EF profile. In that case the
+    # EF code cannot identify a specific suffix, so report the common model
+    # name instead of whichever catalogue entry happens to come first.
     from jura_connect import known_machine_names
 
-    for name, code in known_machine_names():
-        if code == machine_type:
-            friendly = name
-            break
+    matches = [name for name, code in known_machine_names() if code == machine_type]
+    friendly: str | None = matches[0] if matches else None
+    if len(matches) > 1:
+        model_names = {name.partition(" (")[0] for name in matches}
+        if len(model_names) == 1:
+            friendly = model_names.pop()
     return profile, friendly
 
 
@@ -167,19 +170,8 @@ class JuraConnectBackend(JuraBackend):
                 errors=info.status.errors,
                 info=info.status.info,
                 process=info.status.process,
-                counters={
-                    "cleaning": info.maintenance_counters.cleaning,
-                    "filter_change": info.maintenance_counters.filter_change,
-                    "descale": info.maintenance_counters.descale,
-                    "cappu_rinse": info.maintenance_counters.cappu_rinse,
-                    "coffee_rinse": info.maintenance_counters.coffee_rinse,
-                    "cappu_clean": info.maintenance_counters.cappu_clean,
-                },
-                percents={
-                    "cleaning": info.maintenance_percent.cleaning,
-                    "filter_change": info.maintenance_percent.filter_change,
-                    "descale": info.maintenance_percent.descale,
-                },
+                counters=dict(info.maintenance_counters.counters),
+                percents=dict(info.maintenance_percent.percent),
                 raw_status_hex=info.status.raw.hex().upper(),
                 brews=brews,
                 brews_total=brews_total,

--- a/custom_components/jura/manifest.json
+++ b/custom_components/jura/manifest.json
@@ -11,7 +11,7 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/makefu/jura-connect-hass/issues",
     "requirements": [
-        "jura_connect>=0.11.0"
+        "jura_connect>=0.13.0"
     ],
-    "version": "0.10.0"
+    "version": "0.11.0"
 }

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783344391,
-        "narHash": "sha256-f5I1EzyIBeAYHYlve6mRbn2pyhEes8GiGczEP7GO8+o=",
+        "lastModified": 1786879743,
+        "narHash": "sha256-erdlpNze6sL0DuDnmppo1SREsvS/U9EmOBo890//PP8=",
         "owner": "makefu",
         "repo": "jura-connect",
-        "rev": "3fe6beb0489be36f2a3266f4ea7f02892c39fa29",
+        "rev": "78464a5551d56669be32d1797c58102a25f9226a",
         "type": "github"
       },
       "original": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-jura-connect"
-version = "0.10.0"
+version = "0.11.0"
 requires-python = ">=3.13"
 dependencies = [
-    "jura_connect>=0.11.0",
+    "jura_connect>=0.13.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_backends/test_jura.py
+++ b/tests/test_backends/test_jura.py
@@ -16,6 +16,7 @@ simulator = pytest.importorskip("jura_connect.simulator")
 from custom_components.jura.backends import jura as jura_backend  # noqa: E402
 from custom_components.jura.backends.jura import (  # noqa: E402
     JuraConnectBackend,
+    _resolve_profile_and_name,
     machine_type_from_article,
 )
 
@@ -202,6 +203,19 @@ async def test_run_named_status(running_simulator):
 async def test_machine_type_from_article_none_returns_none():
     """A missing article number resolves to no EF code without touching disk."""
     assert await machine_type_from_article(None) is None
+
+
+async def test_machine_type_from_z10_naa_article():
+    """The North American Z10 article selects the shared EF545 profile."""
+    assert await machine_type_from_article(15636) == "EF545"
+
+
+def test_shared_z10_profile_uses_region_neutral_name():
+    """An EF code shared by regional variants must not claim the first one."""
+    profile, friendly = _resolve_profile_and_name("EF545")
+
+    assert profile is not None
+    assert friendly == "Z10"
 
 
 async def test_machine_type_from_article_offloads_blocking_lookup(monkeypatch):


### PR DESCRIPTION
## Summary

- update the integration to `jura_connect` 0.13.0 for the Z10 product-counter correction
- consume profile-driven maintenance counters introduced by 0.13.0
- resolve EF profiles shared by regional variants to a neutral model name (`Z10` for EF545)
- cover article 15636 mapping to EF545 and neutral Z10 naming
- bump the integration version to 0.11.0 and align dependency documentation

## Hardware validation

Validated against a JURA Z10 NAA, article 15636, at EF545M V02.01 / EF545D V01.04:

- PIN-authenticated pairing completed successfully
- EF545 profile loaded
- read-only snapshot returned 21 brew products, settings, product counters, and maintenance data

## Verification

- `nix develop -c pytest tests/ -q` — 200 passed
- `nix develop -c ruff check`
- `nix develop -c ruff format --check`
- `nix build .#checks.x86_64-linux.ty --print-build-logs`
